### PR TITLE
Remove static parameter to handlers

### DIFF
--- a/src/HieVscode.hs
+++ b/src/HieVscode.hs
@@ -37,7 +37,7 @@ run :: IO Int
 run = flip E.catches handlers $ do
 
   flip E.finally finalProc $ do
-    CTRL.run (return ()) () hieHandlers hieOptions
+    CTRL.run (return ()) hieHandlers hieOptions
 
   where
     handlers = [ E.Handler ioExcept
@@ -53,11 +53,11 @@ run = flip E.catches handlers $ do
 hieOptions :: GUI.Options
 hieOptions = def
 
-hieHandlers :: GUI.Handlers a
+hieHandlers :: GUI.Handlers 
 hieHandlers = def {GUI.renameHandler = Just renameRequestHandler }
 
-renameRequestHandler :: GUI.Handler a J.RenameRequest
-renameRequestHandler _ sf (J.RequestMessage _ origId _ _) = do
+renameRequestHandler :: GUI.Handler J.RenameRequest
+renameRequestHandler sf (J.RequestMessage _ origId _ _) = do
   let loc = def :: J.Location
       res  = GUI.makeResponseMessage origId loc
   sf (encode res)

--- a/src/Language/Haskell/LSP/Control.hs
+++ b/src/Language/Haskell/LSP/Control.hs
@@ -27,13 +27,11 @@ import           Text.Parsec
 
 -- ---------------------------------------------------------------------
 
-run :: forall a.
-       IO () -- ^ function to be called once initialize has been received from the client
-    -> a
-    -> GUI.Handlers a
+run :: IO () -- ^ function to be called once initialize has been received from the client
+    -> GUI.Handlers 
     -> GUI.Options
     -> IO Int         -- exit code
-run dp a h o = do
+run dp h o = do
 
   GUI.setupLogger "/tmp/hie-vscode.log" DEBUG
 
@@ -45,7 +43,7 @@ run dp a h o = do
   hSetEncoding  stdout utf8
 
 
-  mvarDat <- newMVar ((GUI.defaultLanguageContextData a h o :: GUI.LanguageContextData a)
+  mvarDat <- newMVar ((GUI.defaultLanguageContextData h o :: GUI.LanguageContextData)
                          { GUI.resSendResponse = sendResponse
                          } )
 
@@ -55,7 +53,7 @@ run dp a h o = do
 
 -- ---------------------------------------------------------------------
 
-ioLoop :: IO () -> MVar (GUI.LanguageContextData a) -> IO ()
+ioLoop :: IO () -> MVar GUI.LanguageContextData -> IO ()
 ioLoop dispatcherProc mvarDat = go BSL.empty
   where
     go :: BSL.ByteString -> IO ()


### PR DESCRIPTION
I removed the resData field in the LanguageContextData struct, as well as the parameter to each handler function that receives this data. 
As far as I can tell, this parameter is not useful because all handlers which take a static context argument can just be partially applied to it before being put in the Handlers struct. 