### PR TITLE
Leave logger initialization to the library user

### DIFF
--- a/src/Language/Haskell/LSP/Control.hs
+++ b/src/Language/Haskell/LSP/Control.hs
@@ -35,8 +35,6 @@ run :: forall a.
     -> IO Int         -- exit code
 run dp a h o = do
 
-  GUI.setupLogger "/tmp/hie-vscode.log" DEBUG
-
   logm $ B.pack "\n\n\n\n\nStarting up server ..."
   hSetBuffering stdin NoBuffering
   hSetEncoding  stdin utf8


### PR DESCRIPTION
The user may wish to setup logging differently to how this library currently does it. This PR removes the setupLogger call in the run function. The logging setup function is still exported for the library user to call if they wish. 