### PR TITLE
Virtual File System

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /tags
 /cabal.project.local
 .stack-work
+/.dir-locals.el

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,19 @@
+dependencies:
+  cache_directories:
+    - "~/.stack"
+    - "~/.cabal"
+  pre:
+    - wget -q -O- https://s3.amazonaws.com/download.fpcomplete.com/ubuntu/fpco.key | sudo apt-key add -
+    - echo 'deb http://download.fpcomplete.com/ubuntu/precise stable main'|sudo tee /etc/apt/sources.list.d/fpco.list
+    - sudo apt-get update && sudo apt-get install stack -y
+  override:
+    - stack setup
+    - stack build -j 2 :
+        timeout: 3600
+    - stack build -j 2 --test --only-dependencies :
+        timeout: 3600
+
+test:
+  override:
+    - stack test haskell-lsp :
+        timeout: 3600

--- a/haskell-lsp.cabal
+++ b/haskell-lsp.cabal
@@ -99,7 +99,7 @@ executable lsp-hello
 
 test-suite haskell-lsp-test
   type:                exitcode-stdio-1.0
-  hs-source-dirs:      test
+  hs-source-dirs:      test src
   main-is:             Main.hs
   other-modules:       Spec
                        VspSpec
@@ -109,7 +109,13 @@ test-suite haskell-lsp-test
                      , directory
                      , hspec
                      -- , hspec-jenkins
-                     , haskell-lsp
+                     , yi-rope
+                     -- , haskell-lsp
+                     , data-default
+                     , bytestring
+                     , hslogger
+                     , text
+                     , unordered-containers
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N -Wall
   default-language:    Haskell2010
 

--- a/haskell-lsp.cabal
+++ b/haskell-lsp.cabal
@@ -97,6 +97,22 @@ executable lsp-hello
                      -- the package library. Comment this out if you want repl changes to propagate
                      , haskell-lsp
 
+test-suite haskell-lsp-test
+  type:                exitcode-stdio-1.0
+  hs-source-dirs:      test
+  main-is:             Main.hs
+  other-modules:       Spec
+                       VspSpec
+  build-depends:       base
+                     , aeson
+                     , containers
+                     , directory
+                     , hspec
+                     -- , hspec-jenkins
+                     , haskell-lsp
+  ghc-options:         -threaded -rtsopts -with-rtsopts=-N -Wall
+  default-language:    Haskell2010
+
 source-repository head
   type:     git
   location: https://github.com/alanz/haskell-lsp

--- a/haskell-lsp.cabal
+++ b/haskell-lsp.cabal
@@ -29,6 +29,7 @@ library
                      , Language.Haskell.LSP.TH.Constants
                      , Language.Haskell.LSP.TH.DataTypesJSON
                      , Language.Haskell.LSP.Utility
+                     , Language.Haskell.LSP.VFS
   -- other-modules:
  -- other-extensions:
   ghc-options:         -Wall
@@ -53,6 +54,7 @@ library
                      , text
                      , time
                      , unordered-containers
+                     , yi-rope
   hs-source-dirs:      src
   default-language:    Haskell2010
 
@@ -67,6 +69,7 @@ executable lsp-hello
                      , Language.Haskell.LSP.Constant
                      , Language.Haskell.LSP.TH.DataTypesJSON
                      , Language.Haskell.LSP.Utility
+                     , Language.Haskell.LSP.VFS
 
   build-depends:       base >=4.9 && <4.10
                      , aeson
@@ -90,6 +93,7 @@ executable lsp-hello
                      , transformers
                      , unordered-containers
                      , vector
+                     , yi-rope
                      -- the package library. Comment this out if you want repl changes to propagate
                      , haskell-lsp
 

--- a/src/Language/Haskell/LSP/Core.hs
+++ b/src/Language/Haskell/LSP/Core.hs
@@ -27,6 +27,7 @@ module Language.Haskell.LSP.Core (
 
 import           Control.Concurrent
 import qualified Control.Exception as E
+import           Control.Monad
 import qualified Data.Aeson as J
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.ByteString.Lazy.Char8 as B
@@ -452,7 +453,7 @@ initializeRequestHandler dispatcherProc mvarCtx req@(J.RequestMessage _ origId _
       Nothing -> return ()
       Just dir -> do
         logs $ "haskell-lsp:initializeRequestHandler: setting current dir to project root:" ++ dir
-        setCurrentDirectory dir
+        unless (null dir) $ setCurrentDirectory dir
 
     let
       getCapabilities :: J.InitializeParams -> C.ClientCapabilities

--- a/src/Language/Haskell/LSP/TH/DataTypesJSON.hs
+++ b/src/Language/Haskell/LSP/TH/DataTypesJSON.hs
@@ -315,7 +315,7 @@ data Position =
   Position
     { _line       :: Int
     , _character  :: Int
-    } deriving (Show, Read, Eq)
+    } deriving (Show, Read, Eq, Ord)
 
 $(deriveJSON lspOptions ''Position)
 
@@ -347,7 +347,7 @@ data Range =
   Range
     { _start :: Position
     , _end   :: Position
-    } deriving (Show, Read, Eq)
+    } deriving (Show, Read, Eq, Ord)
 
 $(deriveJSON lspOptions ''Range)
 

--- a/src/Language/Haskell/LSP/TH/DataTypesJSON.hs
+++ b/src/Language/Haskell/LSP/TH/DataTypesJSON.hs
@@ -36,6 +36,10 @@ instance (Default a) => Default (List a) where
 
 -- ---------------------------------------------------------------------
 
+type Uri = String
+
+-- ---------------------------------------------------------------------
+
 -- | Id used for a request, Can be either a String or an Int
 data LspId = IdInt Int | IdString String
             deriving (Show,Read,Eq)
@@ -364,7 +368,7 @@ interface Location {
 
 data Location =
   Location
-    { _uri   :: String
+    { _uri   :: Uri
     , _range :: Range
     } deriving (Show, Read, Eq)
 
@@ -564,7 +568,7 @@ interface VersionedTextDocumentIdentifier extends TextDocumentIdentifier {
 -}
 data VersionedTextDocumentIdentifier =
   VersionedTextDocumentIdentifier
-    { _uri     :: String
+    { _uri     :: Uri
     , _version :: Int
     } deriving (Show, Read, Eq)
 
@@ -675,7 +679,7 @@ interface TextDocumentIdentifier {
 -}
 data TextDocumentIdentifier =
   TextDocumentIdentifier
-    { _uri :: String
+    { _uri :: Uri
     } deriving (Show, Read, Eq)
 
 $(deriveJSON lspOptions ''TextDocumentIdentifier)
@@ -718,7 +722,7 @@ interface TextDocumentItem {
 
 data TextDocumentItem =
   TextDocumentItem {
-    _uri        :: String
+    _uri        :: Uri
   , _languageId :: String
   , _version    :: Int
   , _text       :: String
@@ -2243,7 +2247,7 @@ instance Default FileChangeType where
 
 data FileEvent =
   FileEvent
-    { _uri  :: String
+    { _uri  :: Uri
     , _type :: FileChangeType
     } deriving (Read,Show,Eq)
 
@@ -2290,7 +2294,7 @@ interface PublishDiagnosticsParams {
 
 data PublishDiagnosticsParams =
   PublishDiagnosticsParams
-    { _uri         :: String
+    { _uri         :: Uri
     , _diagnostics :: List Diagnostic
     } deriving (Read,Show,Eq)
 

--- a/src/Language/Haskell/LSP/VFS.hs
+++ b/src/Language/Haskell/LSP/VFS.hs
@@ -15,6 +15,7 @@ module Language.Haskell.LSP.VFS
   , openVFS
   , changeVFS
   , closeVFS
+
   -- * for tests
   , sortChanges
   , deleteChars

--- a/src/Language/Haskell/LSP/VFS.hs
+++ b/src/Language/Haskell/LSP/VFS.hs
@@ -1,0 +1,68 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE RankNTypes #-}
+
+{-
+
+Manage the "textDocument/didChange" messages to keep a local copy of the files
+in the client workspace, so that tools at the server can operate on them.
+-}
+module Language.Haskell.LSP.VFS
+  (
+    VFS
+  , VirtualFile(..)
+  , getVfs
+  , openVFS
+  , changeVFS
+  , saveVFS
+  , closeVFS
+  ) where
+
+import qualified Data.Aeson as J
+import qualified Data.Map as Map
+import           Language.Haskell.LSP.Constant
+import qualified Language.Haskell.LSP.TH.ClientCapabilities as C
+import qualified Language.Haskell.LSP.TH.DataTypesJSON      as J
+import           Language.Haskell.LSP.Utility
+import qualified Yi.Rope as Yi
+
+data VirtualFile =
+  VirtualFile {
+      _version :: Int
+    , _text    :: Yi.YiString
+    } deriving (Show)
+
+type VFS = Map.Map J.Uri VirtualFile
+
+-- ---------------------------------------------------------------------
+
+getVfs :: forall a.(J.FromJSON a) => VFS -> a -> IO (VirtualFile, VFS)
+getVfs = undefined
+
+-- ---------------------------------------------------------------------
+
+openVFS :: VFS -> J.DidOpenTextDocumentNotification -> IO VFS
+openVFS vfs (J.NotificationMessage _ _ Nothing) = return vfs
+openVFS vfs (J.NotificationMessage _ _ (Just params)) = do
+  let J.DidOpenTextDocumentNotificationParams
+         (J.TextDocumentItem uri _ version text) = params
+  return $ Map.insert uri (VirtualFile version (Yi.fromString text)) vfs
+
+-- ---------------------------------------------------------------------
+
+changeVFS :: VFS -> J.DidChangeTextDocumentNotification -> IO VFS
+changeVFS vfs notification = do
+  return vfs
+
+-- ---------------------------------------------------------------------
+
+saveVFS :: VFS -> J.DidSaveTextDocumentNotification -> IO VFS
+saveVFS vfs notification = do
+  return vfs
+
+-- ---------------------------------------------------------------------
+
+closeVFS :: VFS -> J.DidCloseTextDocumentNotification -> IO VFS
+closeVFS vfs notification = do
+  return vfs
+
+-- ---------------------------------------------------------------------

--- a/src/Language/Haskell/LSP/VFS.hs
+++ b/src/Language/Haskell/LSP/VFS.hs
@@ -15,6 +15,8 @@ module Language.Haskell.LSP.VFS
   , openVFS
   , changeVFS
   , closeVFS
+  -- * for tests
+  , sortChanges
   ) where
 
 import qualified Data.Aeson as J
@@ -124,8 +126,13 @@ applyChanges :: Yi.YiString -> [J.TextDocumentContentChangeEvent] -> Yi.YiString
 applyChanges str changes' = r
   where
     r = undefined
+    changes = sortChanges changes'
+
+sortChanges :: [J.TextDocumentContentChangeEvent] -> [J.TextDocumentContentChangeEvent]
+sortChanges changes = changes'
+  where
     myComp (J.TextDocumentContentChangeEvent (Just r1) _ _)
            (J.TextDocumentContentChangeEvent (Just r2) _ _)
-      = compare r1 r2
+      = compare r2 r1 -- want descending order
     myComp _ _ = EQ
-    changes = sortBy myComp changes'
+    changes' = sortBy myComp changes

--- a/src/Language/Haskell/LSP/VFS.hs
+++ b/src/Language/Haskell/LSP/VFS.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 {-
 
@@ -13,17 +14,23 @@ module Language.Haskell.LSP.VFS
   , getVfs
   , openVFS
   , changeVFS
-  , saveVFS
   , closeVFS
   ) where
 
 import qualified Data.Aeson as J
+import qualified Data.ByteString.Lazy.Char8 as B
+import           Data.List
 import qualified Data.Map as Map
 import           Language.Haskell.LSP.Constant
 import qualified Language.Haskell.LSP.TH.ClientCapabilities as C
 import qualified Language.Haskell.LSP.TH.DataTypesJSON      as J
 import           Language.Haskell.LSP.Utility
 import qualified Yi.Rope as Yi
+
+-- ---------------------------------------------------------------------
+{-# ANN module ("hlint: ignore Eta reduce" :: String) #-}
+{-# ANN module ("hlint: ignore Redundant do" :: String) #-}
+-- ---------------------------------------------------------------------
 
 data VirtualFile =
   VirtualFile {
@@ -35,8 +42,38 @@ type VFS = Map.Map J.Uri VirtualFile
 
 -- ---------------------------------------------------------------------
 
-getVfs :: forall a.(J.FromJSON a) => VFS -> a -> IO (VirtualFile, VFS)
-getVfs = undefined
+-- getVfs :: forall a.(J.FromJSON a) => VFS -> String -> B.ByteString -> IO VFS
+getVfs :: VFS -> String -> B.ByteString -> IO VFS
+getVfs vfs cmd jsonStr = do
+  -- TODO: this approach is horrible, as we have already deserialised the
+  -- message by the time we get here. Need to sort out the types so the call
+  -- works cleanly.
+  -- Even just pass in the existing JSON Value, rather than the ByteString.
+  case cmd of
+    "textDocument/didOpen" -> do
+      case J.eitherDecode jsonStr of
+        Right (m::J.DidOpenTextDocumentNotification) -> openVFS vfs m
+        Left _ -> do
+          logs $ "haskell-lsp:getVfs:wrong type processing" ++ show cmd
+          return vfs
+
+    "textDocument/didChange" -> do
+      case J.eitherDecode jsonStr of
+        Right (m::J.DidChangeTextDocumentNotification) -> changeVFS vfs m
+        Left _ -> do
+          logs $ "haskell-lsp:getVfs:wrong type processing" ++ show cmd
+          return vfs
+
+    "textDocument/didClose" -> do
+      case J.eitherDecode jsonStr of
+        Right (m::J.DidCloseTextDocumentNotification) -> closeVFS vfs m
+        Left _ -> do
+          logs $ "haskell-lsp:getVfs:wrong type processing" ++ show cmd
+          return vfs
+
+    _ -> do
+      logs $ "haskell-lsp:getVfs:not processing" ++ show cmd
+      return vfs
 
 -- ---------------------------------------------------------------------
 
@@ -50,19 +87,45 @@ openVFS vfs (J.NotificationMessage _ _ (Just params)) = do
 -- ---------------------------------------------------------------------
 
 changeVFS :: VFS -> J.DidChangeTextDocumentNotification -> IO VFS
-changeVFS vfs notification = do
-  return vfs
-
--- ---------------------------------------------------------------------
-
-saveVFS :: VFS -> J.DidSaveTextDocumentNotification -> IO VFS
-saveVFS vfs notification = do
-  return vfs
+changeVFS vfs (J.NotificationMessage _ _ Nothing) = return vfs
+changeVFS vfs (J.NotificationMessage _ _ (Just params)) = do
+  let
+    J.DidChangeTextDocumentParams vid (J.List changes) = params
+    J.VersionedTextDocumentIdentifier uri version = vid
+  case Map.lookup uri vfs of
+    Just (VirtualFile _ str) -> do
+      let str' = applyChanges str changes
+      return $ Map.insert uri (VirtualFile version str') vfs
+    Nothing -> do
+      logs $ "haskell-lsp:changeVfs:can't find uri:" ++ show uri
+      return vfs
 
 -- ---------------------------------------------------------------------
 
 closeVFS :: VFS -> J.DidCloseTextDocumentNotification -> IO VFS
-closeVFS vfs notification = do
-  return vfs
+closeVFS vfs (J.NotificationMessage _ _ Nothing) = return vfs
+closeVFS vfs (J.NotificationMessage _ _ (Just params)) = do
+  let J.DidCloseTextDocumentParams (J.TextDocumentIdentifier uri) = params
+  return $ Map.delete uri vfs
 
 -- ---------------------------------------------------------------------
+{-
+
+data TextDocumentContentChangeEvent =
+  TextDocumentContentChangeEvent
+    { _range       :: Maybe Range
+    , _rangeLength :: Maybe Int
+    , _text        :: String
+    } deriving (Read,Show,Eq)
+-}
+
+-- | Apply the list of changes, in descending order of range. Assuming no overlaps.
+applyChanges :: Yi.YiString -> [J.TextDocumentContentChangeEvent] -> Yi.YiString
+applyChanges str changes' = r
+  where
+    r = undefined
+    myComp (J.TextDocumentContentChangeEvent (Just r1) _ _)
+           (J.TextDocumentContentChangeEvent (Just r2) _ _)
+      = compare r1 r2
+    myComp _ _ = EQ
+    changes = sortBy myComp changes'

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,0 +1,22 @@
+module Main where
+
+
+-- import Test.Hspec.Formatters.Jenkins
+import Test.Hspec.Runner
+import qualified Spec
+
+-- ---------------------------------------------------------------------
+
+main :: IO ()
+main = hspec Spec.spec
+
+-- main :: IO ()
+-- main = do
+--   summary <- withFile "results.xml" WriteMode $ \h -> do
+--     let c = defaultConfig
+--           { configFormatter = xmlFormatter
+--           , configHandle = h
+--           }
+--     hspecWith c Spec.spec
+--   unless (summaryFailures summary == 0) $
+--     exitFailure

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,0 +1,9 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover -optF --module-name=Spec #-}
+{-
+
+See https://github.com/hspec/hspec/tree/master/hspec-discover#readme
+to understand this module
+
+Or http://hspec.github.io/hspec-discover.html
+
+-}

--- a/test/VspSpec.hs
+++ b/test/VspSpec.hs
@@ -81,6 +81,22 @@ vspSpec = do
           , "module Foo where"
           , "foo :: Int"
           ]
+    -- ---------------------------------
+
+    it "deletes two lines" $ do
+      -- based on vscode log
+      let
+        orig = unlines
+          [ "module Foo where"
+          , "-- fooo"
+          , "foo :: Int"
+          , "foo = bb"
+          ]
+        new = deleteChars (Yi.fromString orig) (J.Position 1 0) 19
+      lines (Yi.toString new) `shouldBe`
+          [ "module Foo where"
+          , "foo = bb"
+          ]
 
     -- ---------------------------------
 
@@ -97,6 +113,23 @@ vspSpec = do
       lines (Yi.toString new) `shouldBe`
           [ "abcdg"
           , "module Foo where"
+          , "-- fooo"
+          , "foo :: Int"
+          ]
+
+    -- ---------------------------------
+
+    it "adds two lines" $ do
+      -- based on vscode log
+      let
+        orig = unlines
+          [ "module Foo where"
+          , "foo = bb"
+          ]
+        new = addChars (Yi.fromString orig) (J.Position 1 8) "\n-- fooo\nfoo :: Int"
+      lines (Yi.toString new) `shouldBe`
+          [ "module Foo where"
+          , "foo = bb"
           , "-- fooo"
           , "foo :: Int"
           ]

--- a/test/VspSpec.hs
+++ b/test/VspSpec.hs
@@ -1,0 +1,44 @@
+{-# LANGUAGE OverloadedStrings #-}
+module VspSpec where
+
+
+import           Language.Haskell.LSP.VFS
+import qualified Language.Haskell.LSP.TH.DataTypesJSON as J
+
+import           Test.Hspec
+
+-- ---------------------------------------------------------------------
+
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec = describe "VSP functions" vspSpec
+
+-- -- |Used when running from ghci, and it sets the current directory to ./tests
+-- tt :: IO ()
+-- tt = do
+--   cd ".."
+--   hspec spec
+
+-- ---------------------------------------------------------------------
+
+
+mkRange :: Int -> Int -> Int -> Int -> Maybe J.Range
+mkRange ls cs le ce = Just $ J.Range (J.Position ls cs) (J.Position le ce)
+
+-- ---------------------------------------------------------------------
+
+vspSpec :: Spec
+vspSpec = do
+  describe "sorts changes" $ do
+    it "sorts changes that all have ranges" $ do
+      let
+        unsorted =
+          [ (J.TextDocumentContentChangeEvent (mkRange 1 0 2 0) Nothing "")
+          , (J.TextDocumentContentChangeEvent (mkRange 2 0 3 0) Nothing "")
+          ]
+      (sortChanges unsorted) `shouldBe`
+          [ (J.TextDocumentContentChangeEvent (mkRange 2 0 3 0) Nothing "")
+          , (J.TextDocumentContentChangeEvent (mkRange 1 0 2 0) Nothing "")
+          ]


### PR DESCRIPTION
Introduces a virtual file system, in the sense that it processes the `textDocument/didOpen`, `textDocument/didChange` and `textDocument/didClose` notifications to replicate the state of a file being edited in the IDE.

This is accesed in the `Handler` via a new field with signature

```haskell
(J.Uri -> IO (Maybe VirtualFile))
```

where a `VirtualFile` is defined as

```haskell
data VirtualFile =
  VirtualFile {
      _version :: Int
    , _text    :: Yi.YiString
    } deriving (Show)
```