### PR TITLE
Publish diagnostics and simplify Handler interface

### DIFF
--- a/example/Main.hs
+++ b/example/Main.hs
@@ -15,14 +15,14 @@ import           Control.Monad.IO.Class
 import           Control.Monad.STM
 import           Control.Monad.Trans.State.Lazy
 import qualified Data.Aeson as J
-import qualified Data.ByteString.Lazy as BSL
+-- import qualified Data.ByteString.Lazy as BSL
 import           Data.Default
 import qualified Data.HashMap.Strict as H
 import           Data.Maybe
 import qualified Data.Vector as V
 import qualified Language.Haskell.LSP.Control  as CTRL
 import qualified Language.Haskell.LSP.Core     as Core
-import qualified Language.Haskell.LSP.TH.ClientCapabilities as C
+-- import qualified Language.Haskell.LSP.TH.ClientCapabilities as C
 import qualified Language.Haskell.LSP.TH.DataTypesJSON as J
 import qualified Language.Haskell.LSP.Utility  as U
 import           Language.Haskell.LSP.VFS
@@ -53,8 +53,8 @@ run dispatcherProc = flip E.catches handlers $ do
   _rpid  <- forkIO $ reactor def rin
 
   let
-    dp capabilities sendFunc = do
-      atomically $ writeTChan rin (InitializeCallBack capabilities sendFunc)
+    dp lf = do
+      atomically $ writeTChan rin (InitializeCallBack lf)
       dispatcherProc
       return Nothing
 
@@ -77,28 +77,21 @@ run dispatcherProc = flip E.catches handlers $ do
 -- reply sent.
 
 data ReactorInput
-  = InitializeCallBack C.ClientCapabilities Core.SendFunc
+  = InitializeCallBack Core.LspFuncs
       -- ^ called when the LSP ioLoop receives the `initialize` message from the
       -- client, providing the client capabilities (for LSP 3.0 and later)
-  | HandlerRequest
-      (J.Uri -> IO (Maybe VirtualFile))
-      (BSL.ByteString -> IO ())
-      Core.OutMessage
+  | HandlerRequest Core.LspFuncs Core.OutMessage
       -- ^ injected into the reactor input by each of the individual callback handlers
 
 data ReactorState =
   ReactorState
-    { sender             :: !(Maybe (BSL.ByteString -> IO ()))
-        -- ^ function provided in the 'InitializeCallBack' to send reply
-        -- messages to the client.
-    , clientCapabilities :: !(Maybe C.ClientCapabilities)
-        -- ^ client capabilities from the 'InitializeCallBack'
+    { lspFuncs           :: !(Maybe Core.LspFuncs)
     , lspReqId           :: !J.LspId -- ^ unique ids for requests to the client
     -- , wip                :: !(Map.Map RequestId Core.OutMessage)
     }
 
 instance Default ReactorState where
-  def = ReactorState Nothing Nothing (J.IdInt 0)
+  def = ReactorState Nothing (J.IdInt 0)
 
 -- ---------------------------------------------------------------------
 
@@ -109,20 +102,17 @@ type R a = StateT ReactorState IO a
 -- reactor monad functions
 -- ---------------------------------------------------------------------
 
-setSendFunc :: (BSL.ByteString -> IO ()) -> R ()
-setSendFunc sf = modify' (\s -> s {sender = Just sf})
-
-setClientCapabilities :: C.ClientCapabilities -> R ()
-setClientCapabilities c = modify' (\s -> s {clientCapabilities = Just c})
+setLspFuncs :: Core.LspFuncs -> R ()
+setLspFuncs lf = modify' (\s -> s {lspFuncs = Just lf})
 
 -- ---------------------------------------------------------------------
 
 reactorSend :: (J.ToJSON a) => a -> R ()
 reactorSend msg = do
   s <- get
-  case sender s of
+  case lspFuncs s of
     Nothing -> error "reactorSend: send function not initialised yet"
-    Just sf -> liftIO $ sf (J.encode msg)
+    Just lf -> liftIO $ (Core.sendFunc lf) (J.encode msg)
 
 -- ---------------------------------------------------------------------
 
@@ -145,21 +135,18 @@ reactor st inp = do
     case inval of
       -- This will be the first message received from the client, and can be
       -- used to tailor processing according to the given client capabilities.
-      InitializeCallBack capabilities sf -> do
+      InitializeCallBack lf@(Core.LspFuncs capabilities _sf _vf _dpf) -> do
         liftIO $ U.logs $ "reactor:got Client capabilities:" ++ show capabilities
-        setSendFunc sf
-        setClientCapabilities capabilities
+        setLspFuncs lf
 
       -- Handle any response from a message originating at the server, such as
       -- "workspace/applyEdit"
-      HandlerRequest _vf sf (Core.RspFromClient rm) -> do
-        setSendFunc sf
+      HandlerRequest _lf (Core.RspFromClient rm) -> do
         liftIO $ U.logs $ "reactor:got RspFromClient:" ++ show rm
 
       -- -------------------------------
 
-      HandlerRequest _vf sf (Core.NotInitialized _notification) -> do
-        setSendFunc sf
+      HandlerRequest _lf (Core.NotInitialized _notification) -> do
         liftIO $ U.logm $ "****** reactor: processing Initialized Notification"
         -- Server is ready, register any specific capabilities we need
 
@@ -196,28 +183,26 @@ reactor st inp = do
 
       -- -------------------------------
 
-      HandlerRequest _vf sf (Core.NotDidOpenTextDocument notification) -> do
-        setSendFunc sf
+      HandlerRequest _lf (Core.NotDidOpenTextDocument notification) -> do
         liftIO $ U.logm $ "****** reactor: processing NotDidOpenTextDocument"
         let
             params  = fromJust $ J._params (notification :: J.DidOpenTextDocumentNotification)
             textDoc = J._textDocument (params :: J.DidOpenTextDocumentNotificationParams)
             doc     = J._uri (textDoc :: J.TextDocumentItem)
             fileName = drop (length ("file://"::String)) doc
-        liftIO $ U.logs $ "********* doc=" ++ show doc
+        liftIO $ U.logs $ "********* fileName=" ++ show fileName
         sendDiagnostics doc
 
       -- -------------------------------
 
-      HandlerRequest vf sf (Core.NotDidChangeTextDocument notification) -> do
-        setSendFunc sf
+      HandlerRequest (Core.LspFuncs _c _sf vf _pd) (Core.NotDidChangeTextDocument notification) -> do
         let
             params  = fromJust $ J._params (notification :: J.DidChangeTextDocumentNotification)
             textDoc = J._textDocument (params :: J.DidChangeTextDocumentParams)
             doc     = J._uri (textDoc :: J.VersionedTextDocumentIdentifier)
         mdoc <- liftIO $ vf doc
         case mdoc of
-          Just (VirtualFile version str) -> do
+          Just (VirtualFile _version str) -> do
             liftIO $ U.logs $ "reactor:processing NotDidChangeTextDocument: vf got:" ++ (show $ Yi.toString str)
           Nothing -> do
             liftIO $ U.logs $ "reactor:processing NotDidChangeTextDocument: vf returned Nothing"
@@ -226,20 +211,18 @@ reactor st inp = do
 
       -- -------------------------------
 
-      HandlerRequest _vf sf (Core.NotDidSaveTextDocument notification) -> do
-        setSendFunc sf
+      HandlerRequest (Core.LspFuncs _c _sf _vf _pd) (Core.NotDidSaveTextDocument notification) -> do
         liftIO $ U.logm "****** reactor: processing NotDidSaveTextDocument"
         let
             params = fromJust $ J._params (notification :: J.NotificationMessage J.DidSaveTextDocumentParams)
             J.TextDocumentIdentifier doc = J._textDocument (params :: J.DidSaveTextDocumentParams)
             fileName = drop (length ("file://"::String)) doc
-        liftIO $ U.logs $ "********* doc=" ++ show doc
+        liftIO $ U.logs $ "********* fileName=" ++ show fileName
         sendDiagnostics doc
 
       -- -------------------------------
 
-      HandlerRequest _vf sf (Core.ReqRename req) -> do
-        setSendFunc sf
+      HandlerRequest (Core.LspFuncs _c _sf _vf _pd) (Core.ReqRename req) -> do
         liftIO $ U.logs $ "reactor:got RenameRequest:" ++ show req
         let params = fromJust $ J._params (req :: J.RenameRequest)
             J.TextDocumentIdentifier doc = J._textDocument (params :: J.RenameRequestParams)
@@ -255,8 +238,7 @@ reactor st inp = do
 
       -- -------------------------------
 
-      HandlerRequest _vf sf r@(Core.ReqHover req) -> do
-        setSendFunc sf
+      HandlerRequest (Core.LspFuncs _c _sf _vf _pd) (Core.ReqHover req) -> do
         liftIO $ U.logs $ "reactor:got HoverRequest:" ++ show req
         let J.TextDocumentPositionParams doc pos = fromJust $ J._params (req :: J.HoverRequest)
             fileName = drop (length ("file://"::String)) $ J._uri (doc :: J.TextDocumentIdentifier)
@@ -270,8 +252,7 @@ reactor st inp = do
 
       -- -------------------------------
 
-      HandlerRequest _vf sf (Core.ReqCodeAction req) -> do
-        setSendFunc sf
+      HandlerRequest (Core.LspFuncs _c _sf _vf _pd) (Core.ReqCodeAction req) -> do
         liftIO $ U.logs $ "reactor:got CodeActionRequest:" ++ show req
         let params = fromJust $ J._params (req :: J.CodeActionRequest)
             doc = J._textDocument (params :: J.CodeActionParams)
@@ -298,8 +279,7 @@ reactor st inp = do
 
       -- -------------------------------
 
-      HandlerRequest _vf sf (Core.ReqExecuteCommand req) -> do
-        setSendFunc sf
+      HandlerRequest (Core.LspFuncs _c _sf _vf _pd) (Core.ReqExecuteCommand req) -> do
         liftIO $ U.logs $ "reactor:got ExecuteCommandRequest:" -- ++ show req
         let params = fromJust $ J._params (req :: J.ExecuteCommandRequest)
             command = J._command (params :: J.ExecuteCommandParams)
@@ -323,8 +303,7 @@ reactor st inp = do
 
       -- -------------------------------
 
-      HandlerRequest _vf sf om -> do
-        setSendFunc sf
+      HandlerRequest (Core.LspFuncs _c _sf _vf _pd) om -> do
         liftIO $ U.logs $ "reactor:got HandlerRequest:" ++ show om
 
 -- ---------------------------------------------------------------------
@@ -378,13 +357,13 @@ lspHandlers rin
 -- ---------------------------------------------------------------------
 
 passHandler :: TChan ReactorInput -> (a -> Core.OutMessage) -> Core.Handler a
-passHandler rin c vf sf notification = do
-  atomically $ writeTChan rin (HandlerRequest vf sf (c notification))
+passHandler rin c lf notification = do
+  atomically $ writeTChan rin (HandlerRequest lf (c notification))
 
 -- ---------------------------------------------------------------------
 
 responseHandlerCb :: TChan ReactorInput -> Core.Handler J.BareResponseMessage
-responseHandlerCb _rin _vf _sf resp = do
+responseHandlerCb _rin (Core.LspFuncs _c _sf _vf _pd) resp = do
   U.logs $ "******** got ResponseMessage, ignoring:" ++ show resp
 
 -- ---------------------------------------------------------------------

--- a/haskell-lsp.cabal
+++ b/haskell-lsp.cabal
@@ -22,9 +22,10 @@ cabal-version:       >=1.10
 
 
 library
-  exposed-modules:     Language.Haskell.LSP.Core
-                     , Language.Haskell.LSP.Constant
+  exposed-modules:     Language.Haskell.LSP.Constant
+                     , Language.Haskell.LSP.Core
                      , Language.Haskell.LSP.Control
+                     , Language.Haskell.LSP.Diagnostics
                      , Language.Haskell.LSP.TH.ClientCapabilities
                      , Language.Haskell.LSP.TH.Constants
                      , Language.Haskell.LSP.TH.DataTypesJSON
@@ -103,6 +104,7 @@ test-suite haskell-lsp-test
   main-is:             Main.hs
   other-modules:       Spec
                        VspSpec
+                       DiagnosticsSpec
   build-depends:       base
                      , aeson
                      , containers

--- a/src/Language/Haskell/LSP/Control.hs
+++ b/src/Language/Haskell/LSP/Control.hs
@@ -42,9 +42,11 @@ run dp h o = do
   cout <- atomically newTChan :: IO (TChan BSL.ByteString)
   _rhpid <- forkIO $ sendServer cout
 
-  let sendFunc str = atomically $ writeTChan cout str
 
-  mvarDat <- newMVar ((Core.defaultLanguageContextData h o :: Core.LanguageContextData)
+  let sendFunc str = atomically $ writeTChan cout str
+  let lf = error "LifeCycle error, ClientCapabilites not set yet via initialize maessage"
+
+  mvarDat <- newMVar ((Core.defaultLanguageContextData h o lf :: Core.LanguageContextData)
                          { Core.resSendResponse = sendFunc
                          } )
 

--- a/src/Language/Haskell/LSP/Diagnostics.hs
+++ b/src/Language/Haskell/LSP/Diagnostics.hs
@@ -1,0 +1,73 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+{-
+
+Manage the "textDocument/publishDiagnostics" notifications to keep a local copy of the
+diagnostics for a particular file and version, partitioned by source.
+-}
+module Language.Haskell.LSP.Diagnostics
+  (
+    DiagnosticStore
+  , DiagnosticsBySource
+  , StoreItem(..)
+  , updateDiagnostics
+
+  -- * for tests
+  ) where
+
+import qualified Data.Map as Map
+import qualified Language.Haskell.LSP.TH.DataTypesJSON      as J
+
+-- ---------------------------------------------------------------------
+{-# ANN module ("hlint: ignore Eta reduce" :: String) #-}
+{-# ANN module ("hlint: ignore Redundant do" :: String) #-}
+-- ---------------------------------------------------------------------
+
+{-
+We need a three level store
+
+  Uri : Maybe TextDocumentVersion : Maybe DiagnosticSource : [Diagnostics]
+
+For a given Uri, as soon as we see a new (Maybe TextDocumentVersion) we flush
+all prior entries for the Uri.
+
+-}
+
+type DiagnosticStore = Map.Map J.Uri StoreItem
+
+data StoreItem
+  = StoreItem (Maybe J.TextDocumentVersion) DiagnosticsBySource
+  deriving (Show,Eq)
+
+type DiagnosticsBySource = Map.Map (Maybe J.DiagnosticSource) [J.Diagnostic]
+
+-- ---------------------------------------------------------------------
+
+updateDiagnostics :: DiagnosticStore
+                  -> J.Uri -> Maybe J.TextDocumentVersion -> [J.Diagnostic]
+                  -> DiagnosticStore
+updateDiagnostics store uri mv diags = r
+  where
+    newStore :: DiagnosticStore
+    newStore = Map.insert uri (StoreItem mv newDiagsBySource) store
+
+    newDiagsBySource :: DiagnosticsBySource
+    newDiagsBySource = Map.fromListWith (++) $ map (\d -> (J._source d, [d])) diags
+
+    updateDbs dbs = Map.insert uri new store
+      where
+        new = StoreItem mv newDbs
+        -- note: Map.union is left-biased, so for identical keys the first
+        -- argument is used
+        newDbs = Map.union newDiagsBySource dbs
+
+    r = case Map.lookup uri store of
+      Nothing -> newStore
+      Just (StoreItem mvs dbs) ->
+        if mvs /= mv
+          then newStore
+          else updateDbs dbs
+
+-- ---------------------------------------------------------------------

--- a/src/Language/Haskell/LSP/Diagnostics.hs
+++ b/src/Language/Haskell/LSP/Diagnostics.hs
@@ -13,6 +13,7 @@ module Language.Haskell.LSP.Diagnostics
   , DiagnosticsBySource
   , StoreItem(..)
   , updateDiagnostics
+  , getDiagnosticParamsFor
 
   -- * for tests
   ) where
@@ -69,5 +70,14 @@ updateDiagnostics store uri mv diags = r
         if mvs /= mv
           then newStore
           else updateDbs dbs
+
+-- ---------------------------------------------------------------------
+
+getDiagnosticParamsFor :: DiagnosticStore -> J.Uri -> Maybe J.PublishDiagnosticsParams
+getDiagnosticParamsFor ds uri =
+  case Map.lookup uri ds of
+    Nothing -> Nothing
+    Just (StoreItem _ diags) ->
+      Just $ J.PublishDiagnosticsParams uri (J.List (concat $ Map.elems diags))
 
 -- ---------------------------------------------------------------------

--- a/src/Language/Haskell/LSP/TH/DataTypesJSON.hs
+++ b/src/Language/Haskell/LSP/TH/DataTypesJSON.hs
@@ -461,12 +461,14 @@ interface Diagnostic {
     message: string;
 }
 -}
+
+type DiagnosticSource = String
 data Diagnostic =
   Diagnostic
     { _range    :: Range
     , _severity :: Maybe DiagnosticSeverity
     , _code     :: Maybe String -- Note: Protocol allows Int too.
-    , _source   :: Maybe String
+    , _source   :: Maybe DiagnosticSource
     , _message  :: String
     } deriving (Show, Read, Eq)
 
@@ -566,10 +568,13 @@ interface VersionedTextDocumentIdentifier extends TextDocumentIdentifier {
      */
     version: number;
 -}
+
+type TextDocumentVersion = Int
+
 data VersionedTextDocumentIdentifier =
   VersionedTextDocumentIdentifier
     { _uri     :: Uri
-    , _version :: Int
+    , _version :: TextDocumentVersion
     } deriving (Show, Read, Eq)
 
 $(deriveJSON lspOptions ''VersionedTextDocumentIdentifier)

--- a/src/Language/Haskell/LSP/VFS.hs
+++ b/src/Language/Haskell/LSP/VFS.hs
@@ -28,7 +28,6 @@ import qualified Data.Aeson as J
 import qualified Data.ByteString.Lazy.Char8 as B
 import           Data.List
 import qualified Data.Map as Map
--- import qualified Language.Haskell.LSP.TH.ClientCapabilities as C
 import qualified Language.Haskell.LSP.TH.DataTypesJSON      as J
 import           Language.Haskell.LSP.Utility
 import qualified Yi.Rope as Yi
@@ -48,7 +47,6 @@ type VFS = Map.Map J.Uri VirtualFile
 
 -- ---------------------------------------------------------------------
 
--- getVfs :: forall a.(J.FromJSON a) => VFS -> String -> B.ByteString -> IO VFS
 getVfs :: VFS -> String -> B.ByteString -> IO VFS
 getVfs vfs cmd jsonStr = do
   -- TODO: this approach is horrible, as we have already deserialised the

--- a/test/DiagnosticsSpec.hs
+++ b/test/DiagnosticsSpec.hs
@@ -1,0 +1,151 @@
+{-# LANGUAGE OverloadedStrings #-}
+module DiagnosticsSpec where
+
+
+import qualified Data.Map as Map
+import           Language.Haskell.LSP.Diagnostics
+import qualified Language.Haskell.LSP.TH.DataTypesJSON as J
+
+import           Test.Hspec
+
+-- ---------------------------------------------------------------------
+
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec = describe "Diagnostics functions" diagnosticsSpec
+
+-- -- |Used when running from ghci, and it sets the current directory to ./tests
+-- tt :: IO ()
+-- tt = do
+--   cd ".."
+--   hspec spec
+
+-- ---------------------------------------------------------------------
+
+mkDiagnostic :: Maybe J.DiagnosticSource -> String -> J.Diagnostic
+mkDiagnostic ms str = J.Diagnostic (J.Range (J.Position 0 1) (J.Position 3 0)) Nothing Nothing ms str
+
+-- ---------------------------------------------------------------------
+
+diagnosticsSpec :: Spec
+diagnosticsSpec = do
+  describe "constructs a new store" $ do
+    it "constructs a store with no doc version and a single source" $ do
+      let
+        diags =
+          [ mkDiagnostic (Just "hlint") "a"
+          , mkDiagnostic (Just "hlint") "b"
+          ]
+      (updateDiagnostics Map.empty "uri" Nothing diags) `shouldBe`
+        Map.fromList
+          [ ("uri",StoreItem Nothing $ Map.fromList [(Just "hlint", reverse diags) ] )
+          ]
+
+    -- ---------------------------------
+
+    it "constructs a store with no doc version and multiple sources" $ do
+      let
+        diags =
+          [ mkDiagnostic (Just "hlint") "a"
+          , mkDiagnostic (Just "ghcmod") "b"
+          ]
+      (updateDiagnostics Map.empty "uri" Nothing diags) `shouldBe`
+        Map.fromList
+          [ ("uri",StoreItem Nothing $ Map.fromList
+                [(Just "hlint",  [mkDiagnostic (Just "hlint")  "a"]) 
+                ,(Just "ghcmod", [mkDiagnostic (Just "ghcmod") "b"])
+                ])
+          ]
+
+    -- ---------------------------------
+
+    it "constructs a store with doc version and multiple sources" $ do
+      let
+        diags =
+          [ mkDiagnostic (Just "hlint") "a"
+          , mkDiagnostic (Just "ghcmod") "b"
+          ]
+      (updateDiagnostics Map.empty "uri" (Just 1) diags) `shouldBe`
+        Map.fromList
+          [ ("uri",StoreItem (Just 1) $ Map.fromList
+                [(Just "hlint",  [mkDiagnostic (Just "hlint")  "a"]) 
+                ,(Just "ghcmod", [mkDiagnostic (Just "ghcmod") "b"])
+                ])
+          ]
+
+    -- ---------------------------------
+
+  describe "updates a store for same document version" $ do
+    it "updates a store without a document version, single source only" $ do
+      let
+        diags1 =
+          [ mkDiagnostic (Just "hlint") "a1"
+          , mkDiagnostic (Just "hlint") "b1"
+          ]
+        diags2 =
+          [ mkDiagnostic (Just "hlint") "a2"
+          ]
+      let origStore = updateDiagnostics Map.empty "uri" Nothing diags1
+      (updateDiagnostics origStore "uri" Nothing diags2) `shouldBe`
+        Map.fromList
+          [ ("uri",StoreItem Nothing $ Map.fromList [(Just "hlint", diags2) ] )
+          ]
+
+    -- ---------------------------------
+
+    it "updates just one source of a 2 source store" $ do
+      let
+        diags1 =
+          [ mkDiagnostic (Just "hlint") "a1"
+          , mkDiagnostic (Just "ghcmod") "b1"
+          ]
+        diags2 =
+          [ mkDiagnostic (Just "hlint") "a2"
+          ]
+      let origStore = updateDiagnostics Map.empty "uri" Nothing diags1
+      (updateDiagnostics origStore "uri" Nothing diags2) `shouldBe`
+        Map.fromList
+          [ ("uri",StoreItem Nothing $ Map.fromList
+                [(Just "hlint",  [mkDiagnostic (Just "hlint")  "a2"])
+                ,(Just "ghcmod", [mkDiagnostic (Just "ghcmod") "b1"])
+              ] )
+          ]
+
+    -- ---------------------------------
+
+  describe "updates a store for a new document version" $ do
+    it "updates a store without a document version, single source only" $ do
+      let
+        diags1 =
+          [ mkDiagnostic (Just "hlint") "a1"
+          , mkDiagnostic (Just "hlint") "b1"
+          ]
+        diags2 =
+          [ mkDiagnostic (Just "hlint") "a2"
+          ]
+      let origStore = updateDiagnostics Map.empty "uri" (Just 1) diags1
+      (updateDiagnostics origStore "uri" (Just 2) diags2) `shouldBe`
+        Map.fromList
+          [ ("uri",StoreItem (Just 2) $ Map.fromList [(Just "hlint", diags2) ] )
+          ]
+
+    -- ---------------------------------
+
+    it "updates a store for a new doc version, removing all priot sources" $ do
+      let
+        diags1 =
+          [ mkDiagnostic (Just "hlint") "a1"
+          , mkDiagnostic (Just "ghcmod") "b1"
+          ]
+        diags2 =
+          [ mkDiagnostic (Just "hlint") "a2"
+          ]
+      let origStore = updateDiagnostics Map.empty "uri" (Just 1) diags1
+      (updateDiagnostics origStore "uri" (Just 2) diags2) `shouldBe`
+        Map.fromList
+          [ ("uri",StoreItem (Just 2) $ Map.fromList
+                [(Just "hlint",  [mkDiagnostic (Just "hlint")  "a2"])
+              ] )
+          ]

--- a/test/DiagnosticsSpec.hs
+++ b/test/DiagnosticsSpec.hs
@@ -149,3 +149,19 @@ diagnosticsSpec = do
                 [(Just "hlint",  [mkDiagnostic (Just "hlint")  "a2"])
               ] )
           ]
+
+    -- ---------------------------------
+
+  describe "retrieves all the diagnostics for a given uri" $ do
+
+    it "gets diagnostics for multiple sources" $ do
+      let
+        diags =
+          [ mkDiagnostic (Just "hlint") "a"
+          , mkDiagnostic (Just "ghcmod") "b"
+          ]
+      let ds = updateDiagnostics Map.empty "uri" (Just 1) diags
+      (getDiagnosticParamsFor ds "uri") `shouldBe`
+        Just (J.PublishDiagnosticsParams "uri" (J.List $ reverse diags))
+
+    -- ---------------------------------


### PR DESCRIPTION
It is not clear what the expected client behaviour is when receiving diagnostics from multiple sources for the same file, and when it should update what portion of the diagnostics. 

This moves management of the diagnostics into this library, where they are aggregated by document version and source, and sent as a whole when any change for a given version. If diagnostics for a new version are seen the old ones are discarded.

It also introduces the `LspFuncs` structure as the first parameter to a `Handler`, as the number of callback features is growing.

This is currently defined as

```haskell
-- | A function to send a message to the client
type SendFunc = (BSL.ByteString -> IO ())

-- | A function to publish diagnostics. It aggregates all diagnostics pertaining
-- to a particular version of a document, by source, and sends a
-- 'textDocument/publishDiagnostics' notification with the total whenever it is
-- updated.
type PublishDiagnosticsFunc = J.Uri -> Maybe J.TextDocumentVersion -> [J.Diagnostic] -> IO ()

-- | Returned to the server on startup, providing ways to interact with the client.
data LspFuncs =
  LspFuncs
    { clientCapabilities     :: !C.ClientCapabilities
    , sendFunc               :: !SendFunc
    , getVirtualFileFunc     :: !(J.Uri -> IO (Maybe VirtualFile))
    , publishDiagnosticsFunc :: !PublishDiagnosticsFunc
    }
```