### PR TITLE
Simpler user API

### DIFF
--- a/example/Main.hs
+++ b/example/Main.hs
@@ -15,14 +15,13 @@ import           Control.Monad.IO.Class
 import           Control.Monad.STM
 import           Control.Monad.Trans.State.Lazy
 import qualified Data.Aeson as J
--- import qualified Data.ByteString.Lazy as BSL
 import           Data.Default
 import qualified Data.HashMap.Strict as H
 import           Data.Maybe
 import qualified Data.Vector as V
 import qualified Language.Haskell.LSP.Control  as CTRL
 import qualified Language.Haskell.LSP.Core     as Core
--- import qualified Language.Haskell.LSP.TH.ClientCapabilities as C
+import           Language.Haskell.LSP.Messages
 import qualified Language.Haskell.LSP.TH.DataTypesJSON as J
 import qualified Language.Haskell.LSP.Utility  as U
 import           Language.Haskell.LSP.VFS
@@ -187,8 +186,7 @@ reactor st inp = do
         let registrations = J.RegistrationParams (J.List [registration])
         rid <- nextLspReqId
 
-        let smr = J.RequestMessage "2.0" rid "client/registerCapability"  (Just registrations)
-        reactorSend smr
+        reactorSend $ fmServerRegisterCapabilityRequest rid registrations
 
         -- example of showMessageRequest
         let
@@ -196,7 +194,7 @@ reactor st inp = do
                            (Just [J.MessageActionItem "option a", J.MessageActionItem "option b"])
         rid1 <- nextLspReqId
 
-        reactorSend $ J.RequestMessage "2.0" rid1 "window/showMessageRequest"  (Just params)
+        reactorSend $ fmServerShowMessageRequest rid1 params
 
       -- -------------------------------
 
@@ -314,7 +312,8 @@ reactor st inp = do
           Just we -> do
             reply (J.Object mempty)
             lid <- nextLspReqId
-            reactorSend $ J.RequestMessage "2.0" lid "workspace/applyEdit" (Just we)
+            -- reactorSend $ J.RequestMessage "2.0" lid "workspace/applyEdit" (Just we)
+            reactorSend $ fmServerApplyWorkspaceEditRequest lid we
           Nothing ->
             reply r
 
@@ -325,7 +324,7 @@ reactor st inp = do
 
 -- ---------------------------------------------------------------------
 
-toWorkspaceEdit :: t -> Maybe J.WorkspaceEdit
+toWorkspaceEdit :: t -> Maybe J.ApplyWorkspaceEditParams
 toWorkspaceEdit _ = Nothing
 
 -- ---------------------------------------------------------------------

--- a/example/Main.hs
+++ b/example/Main.hs
@@ -204,7 +204,7 @@ reactor st inp = do
         liftIO $ U.logm $ "****** reactor: processing NotDidOpenTextDocument"
         let
             params  = fromJust $ J._params (notification :: J.DidOpenTextDocumentNotification)
-            textDoc = J._textDocument (params :: J.DidOpenTextDocumentNotificationParams)
+            textDoc = J._textDocument (params :: J.DidOpenTextDocumentParams)
             doc     = J._uri (textDoc :: J.TextDocumentItem)
             fileName = drop (length ("file://"::String)) doc
         liftIO $ U.logs $ "********* fileName=" ++ show fileName
@@ -242,9 +242,9 @@ reactor st inp = do
       HandlerRequest (Core.LspFuncs _c _sf _vf _pd) (Core.ReqRename req) -> do
         liftIO $ U.logs $ "reactor:got RenameRequest:" ++ show req
         let params = fromJust $ J._params (req :: J.RenameRequest)
-            J.TextDocumentIdentifier doc = J._textDocument (params :: J.RenameRequestParams)
+            J.TextDocumentIdentifier doc = J._textDocument (params :: J.RenameParams)
             fileName = drop (length ("file://"::String)) doc
-            J.Position l c = J._position (params :: J.RenameRequestParams)
+            J.Position l c = J._position (params :: J.RenameParams)
             newName  = J._newName params
 
         let we = J.WorkspaceEdit
@@ -263,7 +263,7 @@ reactor st inp = do
 
         let
           ht = J.Hover ms (Just range)
-          ms = [J.MarkedString "lsp-hello" "TYPE INFO" ]
+          ms = J.List [J.MarkedString "lsp-hello" "TYPE INFO" ]
           range = J.Range pos pos
         reactorSend $ Core.makeResponseMessage (J.responseId $ J._id (req :: J.HoverRequest) ) ht
 

--- a/haskell-lsp.cabal
+++ b/haskell-lsp.cabal
@@ -26,6 +26,7 @@ library
                      , Language.Haskell.LSP.Core
                      , Language.Haskell.LSP.Control
                      , Language.Haskell.LSP.Diagnostics
+                     , Language.Haskell.LSP.Messages
                      , Language.Haskell.LSP.TH.ClientCapabilities
                      , Language.Haskell.LSP.TH.Constants
                      , Language.Haskell.LSP.TH.DataTypesJSON
@@ -61,16 +62,18 @@ library
 
 executable lsp-hello
   main-is:             Main.hs
-  hs-source-dirs:      example src
+  hs-source-dirs:      example
+                       -- src
   default-language:    Haskell2010
   ghc-options:         -Wall
-  other-modules:       Language.Haskell.LSP.Constant
-                     , Language.Haskell.LSP.Control
-                     , Language.Haskell.LSP.Core
-                     , Language.Haskell.LSP.Constant
-                     , Language.Haskell.LSP.TH.DataTypesJSON
-                     , Language.Haskell.LSP.Utility
-                     , Language.Haskell.LSP.VFS
+  -- other-modules:       Language.Haskell.LSP.Constant
+  --                    , Language.Haskell.LSP.Control
+  --                    , Language.Haskell.LSP.Core
+  --                    , Language.Haskell.LSP.Constant
+  --                    , Language.Haskell.LSP.Messages
+  --                    , Language.Haskell.LSP.TH.DataTypesJSON
+  --                    , Language.Haskell.LSP.Utility
+  --                    , Language.Haskell.LSP.VFS
 
   build-depends:       base >=4.9 && <4.10
                      , aeson

--- a/src/Language/Haskell/LSP/Core.hs
+++ b/src/Language/Haskell/LSP/Core.hs
@@ -38,6 +38,7 @@ import qualified Data.List as L
 import qualified Data.Map as Map
 import qualified Data.Text as T
 import           Language.Haskell.LSP.Constant
+import           Language.Haskell.LSP.Messages
 import qualified Language.Haskell.LSP.TH.ClientCapabilities as C
 import qualified Language.Haskell.LSP.TH.DataTypesJSON      as J
 import           Language.Haskell.LSP.Utility
@@ -129,10 +130,10 @@ data Handlers =
     , completionResolveHandler       :: !(Maybe (Handler J.CompletionItemResolveRequest))
     , signatureHelpHandler           :: !(Maybe (Handler J.SignatureHelpRequest))
     , definitionHandler              :: !(Maybe (Handler J.DefinitionRequest))
-    , referencesHandler              :: !(Maybe (Handler J.FindReferencesRequest))
-    , documentHighlightHandler       :: !(Maybe (Handler J.DocumentHighlightsRequest))
-    , documentSymbolHandler          :: !(Maybe (Handler J.DocumentSymbolsRequest))
-    , workspaceSymbolHandler         :: !(Maybe (Handler J.WorkspaceSymbolsRequest))
+    , referencesHandler              :: !(Maybe (Handler J.ReferencesRequest))
+    , documentHighlightHandler       :: !(Maybe (Handler J.DocumentHighlightRequest))
+    , documentSymbolHandler          :: !(Maybe (Handler J.DocumentSymbolRequest))
+    , workspaceSymbolHandler         :: !(Maybe (Handler J.WorkspaceSymbolRequest))
     , codeActionHandler              :: !(Maybe (Handler J.CodeActionRequest))
     , codeLensHandler                :: !(Maybe (Handler J.CodeLensRequest))
     , codeLensResolveHandler         :: !(Maybe (Handler J.CodeLensResolveRequest))
@@ -150,7 +151,7 @@ data Handlers =
     , willSaveWaitUntilTextDocHandler:: !(Maybe (Handler J.WillSaveWaitUntilTextDocumentResponse))
 
     -- Notifications from the client
-    , didChangeConfigurationParamsHandler      :: !(Maybe (Handler J.DidChangeConfigurationParamsNotification))
+    , didChangeConfigurationParamsHandler      :: !(Maybe (Handler J.DidChangeConfigurationNotification))
     , didOpenTextDocumentNotificationHandler   :: !(Maybe (Handler J.DidOpenTextDocumentNotification))
     , didChangeTextDocumentNotificationHandler :: !(Maybe (Handler J.DidChangeTextDocumentNotification))
     , didCloseTextDocumentNotificationHandler  :: !(Maybe (Handler J.DidCloseTextDocumentNotification))
@@ -245,10 +246,10 @@ data OutMessage = ReqHover                    J.HoverRequest
                 | ReqCompletionItemResolve    J.CompletionItemResolveRequest
                 | ReqSignatureHelp            J.SignatureHelpRequest
                 | ReqDefinition               J.DefinitionRequest
-                | ReqFindReferences           J.FindReferencesRequest
-                | ReqDocumentHighlights       J.DocumentHighlightsRequest
-                | ReqDocumentSymbols          J.DocumentSymbolsRequest
-                | ReqWorkspaceSymbols         J.WorkspaceSymbolsRequest
+                | ReqFindReferences           J.ReferencesRequest
+                | ReqDocumentHighlights       J.DocumentHighlightRequest
+                | ReqDocumentSymbols          J.DocumentSymbolRequest
+                | ReqWorkspaceSymbols         J.WorkspaceSymbolRequest
                 | ReqCodeAction               J.CodeActionRequest
                 | ReqCodeLens                 J.CodeLensRequest
                 | ReqCodeLensResolve          J.CodeLensResolveRequest
@@ -263,7 +264,7 @@ data OutMessage = ReqHover                    J.HoverRequest
                 | RspCompletionItemResolve    J.CompletionItemResolveResponse
                 | RspSignatureHelp            J.SignatureHelpResponse
                 | RspDefinition               J.DefinitionResponse
-                | RspFindReferences           J.FindReferencesResponse
+                | RspFindReferences           J.ReferencesResponse
                 | RspDocumentHighlights       J.DocumentHighlightsResponse
                 | RspDocumentSymbols          J.DocumentSymbolsResponse
                 | RspWorkspaceSymbols         J.WorkspaceSymbolsResponse
@@ -278,7 +279,7 @@ data OutMessage = ReqHover                    J.HoverRequest
 
                 -- notifications
                 | NotInitialized                  J.InitializedNotification
-                | NotDidChangeConfigurationParams J.DidChangeConfigurationParamsNotification
+                | NotDidChangeConfigurationParams J.DidChangeConfigurationNotification
                 | NotDidOpenTextDocument          J.DidOpenTextDocumentNotification
                 | NotDidChangeTextDocument        J.DidChangeTextDocumentNotification
                 | NotDidCloseTextDocument         J.DidCloseTextDocumentNotification
@@ -432,14 +433,14 @@ sendErrorLog mv msg = sendErrorLogS (sendEvent mv) msg
 
 sendErrorLogS :: (B.ByteString -> IO ()) -> String -> IO ()
 sendErrorLogS sf msg =
-  sf $ J.encode (J.defLogMessage J.MtError msg)
+  sf $ J.encode (fmServerLogMessageNotification J.MtError msg)
 
 -- sendErrorShow :: String -> IO ()
 -- sendErrorShow msg = sendErrorShowS sendEvent msg
 
 sendErrorShowS :: (B.ByteString -> IO ()) -> String -> IO ()
 sendErrorShowS sf msg =
-  sf $ J.encode (J.defShowMessage J.MtError msg)
+  sf $ J.encode (fmServerShowMessageNotification J.MtError msg)
 
 -- ---------------------------------------------------------------------
 

--- a/src/Language/Haskell/LSP/Messages.hs
+++ b/src/Language/Haskell/LSP/Messages.hs
@@ -180,7 +180,7 @@ fmClientExecuteCommandRequest rid params
 -- | From 3.0
 fmServerApplyWorkspaceEditRequest :: J.LspId -> J.ApplyWorkspaceEditParams -> J.ApplyWorkspaceEditRequest
 fmServerApplyWorkspaceEditRequest rid params
-  = J.RequestMessage  "2.0" rid "workspace/executeCommand" (Just params)
+  = J.RequestMessage  "2.0" rid "workspace/applyEdit" (Just params)
 
 -- ----------------------------------------------------------------------
  -- Document
@@ -199,7 +199,7 @@ fmClientDidOpenTextDocumentNotification params
 -- * :arrow_right: [textDocument/didChange](#textDocument_didChange)
 fmClientDidChangeTextDocumentNotification :: J.DidChangeTextDocumentParams -> J.DidChangeTextDocumentNotification
 fmClientDidChangeTextDocumentNotification params
-  = J.NotificationMessage "2.0" "textDocument/didOpen" (Just params)
+  = J.NotificationMessage "2.0" "textDocument/didChange" (Just params)
 
 -- * :arrow_right: [textDocument/willSave](#textDocument_willSave)
 fmClientWillSaveTextDocumentNotification :: J.WillSaveTextDocumentParams -> J.WillSaveTextDocumentNotification
@@ -261,7 +261,7 @@ fmClientDocumentSymbolRequest rid params
 -- * :leftwards_arrow_with_hook: [textDocument/formatting](#textDocument_formatting)
 fmClientDocumentFormattingRequest :: J.LspId -> J.DocumentFormattingParams -> J.DocumentFormattingRequest
 fmClientDocumentFormattingRequest rid params
-  = J.RequestMessage "2.0" rid "textDocument/documentFormatting" (Just params)
+  = J.RequestMessage "2.0" rid "textDocument/formatting" (Just params)
 
 -- * :leftwards_arrow_with_hook: [textDocument/rangeFormatting](#textDocument_rangeFormatting)
 fmClientDocumentRangeFormattingRequest :: J.LspId -> J.DocumentRangeFormattingParams -> J.DocumentRangeFormattingRequest

--- a/src/Language/Haskell/LSP/Messages.hs
+++ b/src/Language/Haskell/LSP/Messages.hs
@@ -21,8 +21,8 @@ module Language.Haskell.LSP.Messages (
   , fmServerTelemetryNotification
 
   -- * Client
-  , fmClientRegisterCapabilityRequest
-  , fmClientUnregisterCapabilityRequest
+  , fmServerRegisterCapabilityRequest
+  , fmServerUnregisterCapabilityRequest
 
   -- * Workspace
   , fmServerDidChangeConfigurationNotification
@@ -58,31 +58,8 @@ module Language.Haskell.LSP.Messages (
   , fmClientRenameRequest
   ) where
 
--- import           Control.Concurrent
--- import qualified Control.Exception as E
--- import           Control.Monad
 import qualified Data.Aeson as J
--- import qualified Data.ByteString.Lazy as BSL
--- import qualified Data.ByteString.Lazy.Char8 as B
--- import           Data.Default
--- import qualified Data.HashMap.Strict as HM
--- import qualified Data.List as L
--- import qualified Data.Map as Map
--- import qualified Data.Text as T
--- import           Language.Haskell.LSP.Constant
--- import qualified Language.Haskell.LSP.TH.ClientCapabilities as C
 import qualified Language.Haskell.LSP.TH.DataTypesJSON      as J
--- import           Language.Haskell.LSP.Utility
--- import           Language.Haskell.LSP.VFS
--- import           Language.Haskell.LSP.Diagnostics
--- import           System.Directory
--- import           System.Exit
--- import           System.IO
--- import qualified System.Log.Formatter as L
--- import qualified System.Log.Handler as LH
--- import qualified System.Log.Handler.Simple as LHS
--- import           System.Log.Logger
--- import qualified System.Log.Logger as L
 
 -- ---------------------------------------------------------------------
 {-# ANN module ("HLint: ignore Eta reduce"         :: String) #-}
@@ -164,14 +141,14 @@ fmServerTelemetryNotification params
 
 -- * :arrow_right_hook: [client/registerCapability](#client_registerCapability)
 -- | from 3.0
-fmClientRegisterCapabilityRequest :: J.LspId -> J.RegistrationParams -> J.RegisterCapabilityRequest
-fmClientRegisterCapabilityRequest rid params
+fmServerRegisterCapabilityRequest :: J.LspId -> J.RegistrationParams -> J.RegisterCapabilityRequest
+fmServerRegisterCapabilityRequest rid params
   = J.RequestMessage  "2.0" rid "client/registerCapability" (Just params)
 
 -- * :arrow_right_hook: [client/unregisterCapability](#client_unregisterCapability)
 -- | from 3.0
-fmClientUnregisterCapabilityRequest :: J.LspId -> J.UnregistrationParams -> J.UnregisterCapabilityRequest
-fmClientUnregisterCapabilityRequest rid params
+fmServerUnregisterCapabilityRequest :: J.LspId -> J.UnregistrationParams -> J.UnregisterCapabilityRequest
+fmServerUnregisterCapabilityRequest rid params
   = J.RequestMessage  "2.0" rid "client/unregisterCapability" (Just params)
 
 -- ----------------------------------------------------------------------

--- a/src/Language/Haskell/LSP/Messages.hs
+++ b/src/Language/Haskell/LSP/Messages.hs
@@ -1,0 +1,333 @@
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE MultiWayIf          #-}
+{-# LANGUAGE BinaryLiterals      #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Language.Haskell.LSP.Messages (
+  -- * General
+    fmClientInitializeRequest
+  , fmClientInitializedNotification
+  , fmClientShutdownRequest
+  , fmClientExitNotification
+  , fmClientCancelNotification
+
+  -- * Window
+  , fmServerShowMessageNotification
+  , fmServerShowMessageRequest
+  , fmServerLogMessageNotification
+  , fmServerTelemetryNotification
+
+  -- * Client
+  , fmClientRegisterCapabilityRequest
+  , fmClientUnregisterCapabilityRequest
+
+  -- * Workspace
+  , fmServerDidChangeConfigurationNotification
+  , fmServerDidChangeWatchedFilesNotification
+  , fmClientWorkspaceSymbolRequest
+  , fmClientExecuteCommandRequest
+  , fmServerApplyWorkspaceEditRequest
+
+  -- * Document
+  , fmServerPublishDiagnosticsNotification
+  , fmClientDidOpenTextDocumentNotification
+  , fmClientDidChangeTextDocumentNotification
+  , fmClientWillSaveTextDocumentNotification
+  , fmClientWillSaveWaitUntilRequest
+  , fmClientDidSaveTextDocumentNotification
+  , fmClientDidCloseTextDocumentNotification
+  , fmClientCompletionRequest
+  , fmClientCompletionItemResolveRequest
+  , fmClientHoverRequest
+  , fmClientSignatureHelpRequest
+  , fmClientReferencesRequest
+  , fmClientDocumentHighlightRequest
+  , fmClientDocumentSymbolRequest
+  , fmClientDocumentFormattingRequest
+  , fmClientDocumentRangeFormattingRequest
+  , fmClientDocumentOnTypeFormattingRequest
+  , fmClientDefinitionRequest
+  , fmClientCodeActionRequest
+  , fmClientCodeLensRequest
+  , fmClientCodeLensResolveRequest
+  , fmClientDocumentLinkRequest
+  , fmClientDocumentLinkResolveRequest
+  , fmClientRenameRequest
+  ) where
+
+-- import           Control.Concurrent
+-- import qualified Control.Exception as E
+-- import           Control.Monad
+import qualified Data.Aeson as J
+-- import qualified Data.ByteString.Lazy as BSL
+-- import qualified Data.ByteString.Lazy.Char8 as B
+-- import           Data.Default
+-- import qualified Data.HashMap.Strict as HM
+-- import qualified Data.List as L
+-- import qualified Data.Map as Map
+-- import qualified Data.Text as T
+-- import           Language.Haskell.LSP.Constant
+-- import qualified Language.Haskell.LSP.TH.ClientCapabilities as C
+import qualified Language.Haskell.LSP.TH.DataTypesJSON      as J
+-- import           Language.Haskell.LSP.Utility
+-- import           Language.Haskell.LSP.VFS
+-- import           Language.Haskell.LSP.Diagnostics
+-- import           System.Directory
+-- import           System.Exit
+-- import           System.IO
+-- import qualified System.Log.Formatter as L
+-- import qualified System.Log.Handler as LH
+-- import qualified System.Log.Handler.Simple as LHS
+-- import           System.Log.Logger
+-- import qualified System.Log.Logger as L
+
+-- ---------------------------------------------------------------------
+{-# ANN module ("HLint: ignore Eta reduce"         :: String) #-}
+{-# ANN module ("HLint: ignore Redundant do"       :: String) #-}
+{-# ANN module ("HLint: ignore Reduce duplication" :: String) #-}
+-- ---------------------------------------------------------------------
+
+-- ----------------------------------------------------------------------
+-- General
+-- ----------------------------------------------------------------------
+
+-- * :leftwards_arrow_with_hook: [initialize](#initialize)
+
+fmClientInitializeRequest :: J.LspId -> J.InitializeParams -> J.InitializeRequest
+fmClientInitializeRequest rid params
+  = J.RequestMessage  "2.0" rid "initialize" (Just params)
+
+-- ----------------------------------------------------------------------
+-- * **New** :arrow_right: [initialized](#initialized)
+
+-- | From 3.0
+fmClientInitializedNotification :: J.InitializedNotification
+fmClientInitializedNotification = J.NotificationMessage "2.0" "initialized" Nothing
+
+-- ----------------------------------------------------------------------
+-- * :leftwards_arrow_with_hook: [shutdown](#shutdown)
+
+fmClientShutdownRequest :: J.LspId -> Maybe J.Value -> J.ShutdownRequest
+fmClientShutdownRequest rid params
+  = J.RequestMessage  "2.0" rid "shutdown" params
+
+-- ----------------------------------------------------------------------
+-- * :arrow_right: [exit](#exit)
+
+fmClientExitNotification :: J.ExitNotification
+fmClientExitNotification = J.NotificationMessage "2.0" "exit" Nothing
+
+-- ----------------------------------------------------------------------
+-- * :arrow_right: [$/cancelRequest](#cancelRequest)
+
+fmClientCancelNotification :: J.LspId -> J.CancelNotification
+fmClientCancelNotification idToCancel
+  = J.NotificationMessage "2.0" "$/cancelRequest" (Just (J.CancelParams idToCancel))
+
+-- ----------------------------------------------------------------------
+-- Window
+-- ----------------------------------------------------------------------
+
+-- * :arrow_left: [window/showMessage](#window_showMessage)
+
+fmServerShowMessageNotification :: J.MessageType -> String -> J.ShowMessageNotification
+fmServerShowMessageNotification mt msg
+  = J.NotificationMessage "2.0" "window/showMessage" (Just $ J.ShowMessageParams mt msg)
+
+-- ----------------------------------------------------------------------
+-- * :arrow_right_hook: [window/showMessageRequest](#window_showMessageRequest)
+
+fmServerShowMessageRequest :: J.LspId -> J.ShowMessageRequestParams -> J.ShowMessageRequest
+fmServerShowMessageRequest rid params
+  = J.RequestMessage  "2.0" rid "window/showMessageRequest" (Just params)
+
+-- ----------------------------------------------------------------------
+-- * :arrow_left: [window/logMessage](#window_logMessage)
+
+fmServerLogMessageNotification :: J.MessageType -> String -> J.LogMessageNotification
+fmServerLogMessageNotification mt msg
+  = J.NotificationMessage "2.0" "window/logMessage" (Just $ J.LogMessageParams mt msg)
+
+-- ----------------------------------------------------------------------
+-- * :arrow_left: [telemetry/event](#telemetry_event)
+
+fmServerTelemetryNotification :: Maybe J.Value  -> J.TelemetryNotification
+fmServerTelemetryNotification params
+  = J.NotificationMessage "2.0" "telemetry/event" params
+
+-- ----------------------------------------------------------------------
+--  Client
+-- ----------------------------------------------------------------------
+
+-- * :arrow_right_hook: [client/registerCapability](#client_registerCapability)
+-- | from 3.0
+fmClientRegisterCapabilityRequest :: J.LspId -> J.RegistrationParams -> J.RegisterCapabilityRequest
+fmClientRegisterCapabilityRequest rid params
+  = J.RequestMessage  "2.0" rid "client/registerCapability" (Just params)
+
+-- * :arrow_right_hook: [client/unregisterCapability](#client_unregisterCapability)
+-- | from 3.0
+fmClientUnregisterCapabilityRequest :: J.LspId -> J.UnregistrationParams -> J.UnregisterCapabilityRequest
+fmClientUnregisterCapabilityRequest rid params
+  = J.RequestMessage  "2.0" rid "client/unregisterCapability" (Just params)
+
+-- ----------------------------------------------------------------------
+-- Workspace
+-- ----------------------------------------------------------------------
+
+-- * :arrow_right: [workspace/didChangeConfiguration](#workspace_didChangeConfiguration)
+fmServerDidChangeConfigurationNotification :: J.DidChangeConfigurationParams -> J.DidChangeConfigurationNotification
+fmServerDidChangeConfigurationNotification params
+  = J.NotificationMessage "2.0" "workspace/didChangeConfiguration" (Just params)
+
+-- * :arrow_right: [workspace/didChangeWatchedFiles](#workspace_didChangeWatchedFiles)
+fmServerDidChangeWatchedFilesNotification :: J.DidChangeWatchedFilesParams -> J.DidChangeWatchedFilesNotification
+fmServerDidChangeWatchedFilesNotification params
+  = J.NotificationMessage "2.0" "workspace/didChangeWatchedFiles" (Just params)
+
+-- * :leftwards_arrow_with_hook: [workspace/symbol](#workspace_symbol)
+fmClientWorkspaceSymbolRequest :: J.LspId -> J.WorkspaceSymbolParams -> J.WorkspaceSymbolRequest
+fmClientWorkspaceSymbolRequest rid params
+  = J.RequestMessage  "2.0" rid "workspace/symbol" (Just params)
+
+-- * **New** :leftwards_arrow_with_hook: [workspace/executeCommand](#workspace_executeCommand)
+-- | From 3.0
+fmClientExecuteCommandRequest :: J.LspId -> J.ExecuteCommandParams -> J.ExecuteCommandRequest
+fmClientExecuteCommandRequest rid params
+  = J.RequestMessage  "2.0" rid "workspace/executeCommand" (Just params)
+
+-- * **New** :arrow_right_hook: [workspace/applyEdit](#workspace_applyEdit)
+-- | From 3.0
+fmServerApplyWorkspaceEditRequest :: J.LspId -> J.ApplyWorkspaceEditParams -> J.ApplyWorkspaceEditRequest
+fmServerApplyWorkspaceEditRequest rid params
+  = J.RequestMessage  "2.0" rid "workspace/executeCommand" (Just params)
+
+-- ----------------------------------------------------------------------
+ -- Document
+-- ----------------------------------------------------------------------
+
+-- * :arrow_left: [textDocument/publishDiagnostics](#textDocument_publishDiagnostics)
+fmServerPublishDiagnosticsNotification :: J.PublishDiagnosticsParams -> J.PublishDiagnosticsNotification
+fmServerPublishDiagnosticsNotification params
+  = J.NotificationMessage "2.0" "textDocument/publishDiagnostics" (Just params)
+
+-- * :arrow_right: [textDocument/didOpen](#textDocument_didOpen)
+fmClientDidOpenTextDocumentNotification :: J.DidOpenTextDocumentParams -> J.DidOpenTextDocumentNotification
+fmClientDidOpenTextDocumentNotification params
+  = J.NotificationMessage "2.0" "textDocument/didOpen" (Just params)
+
+-- * :arrow_right: [textDocument/didChange](#textDocument_didChange)
+fmClientDidChangeTextDocumentNotification :: J.DidChangeTextDocumentParams -> J.DidChangeTextDocumentNotification
+fmClientDidChangeTextDocumentNotification params
+  = J.NotificationMessage "2.0" "textDocument/didOpen" (Just params)
+
+-- * :arrow_right: [textDocument/willSave](#textDocument_willSave)
+fmClientWillSaveTextDocumentNotification :: J.WillSaveTextDocumentParams -> J.WillSaveTextDocumentNotification
+fmClientWillSaveTextDocumentNotification params
+  = J.NotificationMessage "2.0" "textDocument/willSave" (Just params)
+
+-- * **New** :leftwards_arrow_with_hook: [textDocument/willSaveWaitUntil](#textDocument_willSaveWaitUntil)
+-- | From 3.0
+fmClientWillSaveWaitUntilRequest :: J.LspId -> J.WillSaveTextDocumentParams -> J.WillSaveWaitUntilTextDocumentRequest
+fmClientWillSaveWaitUntilRequest rid params
+  = J.RequestMessage "2.0" rid "textDocument/willSaveWaitUntil" (Just params)
+
+-- * **New** :arrow_right: [textDocument/didSave](#textDocument_didSave)
+-- | 3.0
+fmClientDidSaveTextDocumentNotification :: J.DidSaveTextDocumentParams -> J.DidSaveTextDocumentNotification
+fmClientDidSaveTextDocumentNotification params
+  = J.NotificationMessage "2.0" "textDocument/didSave" (Just params)
+
+-- * :arrow_right: [textDocument/didClose](#textDocument_didClose)
+fmClientDidCloseTextDocumentNotification :: J.DidCloseTextDocumentParams -> J.DidCloseTextDocumentNotification
+fmClientDidCloseTextDocumentNotification params
+  = J.NotificationMessage "2.0" "textDocument/didClose" (Just params)
+
+-- * :leftwards_arrow_with_hook: [textDocument/completion](#textDocument_completion)
+fmClientCompletionRequest :: J.LspId -> J.TextDocumentPositionParams -> J.CompletionRequest
+fmClientCompletionRequest rid params
+  = J.RequestMessage "2.0" rid "textDocument/completion" (Just params)
+
+-- * :leftwards_arrow_with_hook: [completionItem/resolve](#completionItem_resolve)
+fmClientCompletionItemResolveRequest :: J.LspId -> J.CompletionItem -> J.CompletionItemResolveRequest
+fmClientCompletionItemResolveRequest rid params
+  = J.RequestMessage "2.0" rid "completionItem/resolve" (Just params)
+
+-- * :leftwards_arrow_with_hook: [textDocument/hover](#textDocument_hover)
+fmClientHoverRequest :: J.LspId -> J.TextDocumentPositionParams -> J.HoverRequest
+fmClientHoverRequest rid params
+  = J.RequestMessage "2.0" rid "textDocument/hover" (Just params)
+
+-- * :leftwards_arrow_with_hook: [textDocument/signatureHelp](#textDocument_signatureHelp)
+fmClientSignatureHelpRequest :: J.LspId -> J.TextDocumentPositionParams -> J.SignatureHelpRequest
+fmClientSignatureHelpRequest rid params
+  = J.RequestMessage "2.0" rid "textDocument/signatureHelp" (Just params)
+
+-- * :leftwards_arrow_with_hook: [textDocument/references](#textDocument_references)
+fmClientReferencesRequest :: J.LspId -> J.ReferenceParams -> J.ReferencesRequest
+fmClientReferencesRequest rid params
+  = J.RequestMessage "2.0" rid "textDocument/references" (Just params)
+
+-- * :leftwards_arrow_with_hook: [textDocument/documentHighlight](#textDocument_documentHighlight)
+fmClientDocumentHighlightRequest :: J.LspId -> J.TextDocumentPositionParams -> J.DocumentHighlightRequest
+fmClientDocumentHighlightRequest rid params
+  = J.RequestMessage "2.0" rid "textDocument/documentHighlight" (Just params)
+
+-- * :leftwards_arrow_with_hook: [textDocument/documentSymbol](#textDocument_documentSymbol)
+fmClientDocumentSymbolRequest :: J.LspId -> J.DocumentSymbolParams -> J.DocumentSymbolRequest
+fmClientDocumentSymbolRequest rid params
+  = J.RequestMessage "2.0" rid "textDocument/documentSymbol" (Just params)
+
+-- * :leftwards_arrow_with_hook: [textDocument/formatting](#textDocument_formatting)
+fmClientDocumentFormattingRequest :: J.LspId -> J.DocumentFormattingParams -> J.DocumentFormattingRequest
+fmClientDocumentFormattingRequest rid params
+  = J.RequestMessage "2.0" rid "textDocument/documentFormatting" (Just params)
+
+-- * :leftwards_arrow_with_hook: [textDocument/rangeFormatting](#textDocument_rangeFormatting)
+fmClientDocumentRangeFormattingRequest :: J.LspId -> J.DocumentRangeFormattingParams -> J.DocumentRangeFormattingRequest
+fmClientDocumentRangeFormattingRequest rid params
+  = J.RequestMessage "2.0" rid "textDocument/rangeFormatting" (Just params)
+
+-- * :leftwards_arrow_with_hook: [textDocument/onTypeFormatting](#textDocument_onTypeFormatting)
+fmClientDocumentOnTypeFormattingRequest :: J.LspId -> J.DocumentOnTypeFormattingParams -> J.DocumentOnTypeFormattingRequest
+fmClientDocumentOnTypeFormattingRequest rid params
+  = J.RequestMessage "2.0" rid "textDocument/onTypeFormatting" (Just params)
+
+-- * :leftwards_arrow_with_hook: [textDocument/definition](#textDocument_definition)
+fmClientDefinitionRequest :: J.LspId -> J.TextDocumentPositionParams -> J.DefinitionRequest
+fmClientDefinitionRequest rid params
+  = J.RequestMessage "2.0" rid "textDocument/definition" (Just params)
+
+-- * :leftwards_arrow_with_hook: [textDocument/codeAction](#textDocument_codeAction)
+fmClientCodeActionRequest :: J.LspId -> J.CodeActionParams -> J.CodeActionRequest
+fmClientCodeActionRequest rid params
+  = J.RequestMessage "2.0" rid "textDocument/codeAction" (Just params)
+
+-- * :leftwards_arrow_with_hook: [textDocument/codeLens](#textDocument_codeLens)
+fmClientCodeLensRequest :: J.LspId -> J.CodeLensParams -> J.CodeLensRequest
+fmClientCodeLensRequest rid params
+  = J.RequestMessage "2.0" rid "textDocument/codeLens" (Just params)
+
+-- * :leftwards_arrow_with_hook: [codeLens/resolve](#codeLens_resolve)
+fmClientCodeLensResolveRequest :: J.LspId -> J.CodeLens -> J.CodeLensResolveRequest
+fmClientCodeLensResolveRequest rid params
+  = J.RequestMessage "2.0" rid "codeLens/resolve" (Just params)
+
+-- * :leftwards_arrow_with_hook: [textDocument/documentLink](#textDocument_documentLink)
+fmClientDocumentLinkRequest :: J.LspId -> J.DocumentLinkParams -> J.DocumentLinkRequest
+fmClientDocumentLinkRequest rid params
+  = J.RequestMessage "2.0" rid "textDocument/documentLink" (Just params)
+
+-- * :leftwards_arrow_with_hook: [documentLink/resolve](#documentLink_resolve)
+fmClientDocumentLinkResolveRequest :: J.LspId -> J.DocumentLink -> J.DocumentLinkResolveRequest
+fmClientDocumentLinkResolveRequest rid params
+  = J.RequestMessage "2.0" rid "documentLink/resolve" (Just params)
+
+-- * :leftwards_arrow_with_hook: [textDocument/rename](#textDocument_rename)
+fmClientRenameRequest :: J.LspId -> J.RenameParams -> J.RenameRequest
+fmClientRenameRequest rid params
+  = J.RequestMessage "2.0" rid "textDocument/rename" (Just params)
+

--- a/src/Language/Haskell/LSP/VFS.hs
+++ b/src/Language/Haskell/LSP/VFS.hs
@@ -84,7 +84,7 @@ getVfs vfs cmd jsonStr = do
 openVFS :: VFS -> J.DidOpenTextDocumentNotification -> IO VFS
 openVFS vfs (J.NotificationMessage _ _ Nothing) = return vfs
 openVFS vfs (J.NotificationMessage _ _ (Just params)) = do
-  let J.DidOpenTextDocumentNotificationParams
+  let J.DidOpenTextDocumentParams
          (J.TextDocumentItem uri _ version text) = params
   return $ Map.insert uri (VirtualFile version (Yi.fromString text)) vfs
 


### PR DESCRIPTION
Introduce a new `Messages` module that mirrors the sequence in the [spec](https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md#messages-overview), and provides smart constructors for the messages.

This means the mapping of message methods to types happens in one place only.

