### PR TITLE
Resolve warnings about unused local binds and imports.

### DIFF
--- a/example/Main.hs
+++ b/example/Main.hs
@@ -244,10 +244,10 @@ reactor st inp = do
       HandlerRequest (Core.LspFuncs _c _sf _vf _pd) (Core.ReqRename req) -> do
         liftIO $ U.logs $ "reactor:got RenameRequest:" ++ show req
         let
-            params = req ^. J.params
-            doc  = params ^. J.textDocument . J.uri
-            J.Position l c = params ^. J.position
-            newName  = params ^. J.newName
+            _params = req ^. J.params
+            _doc  = _params ^. J.textDocument . J.uri
+            J.Position _l _c' = _params ^. J.position
+            _newName  = _params ^. J.newName
 
         let we = J.WorkspaceEdit
                     Nothing -- "changes" field is deprecated
@@ -259,8 +259,8 @@ reactor st inp = do
 
       HandlerRequest (Core.LspFuncs _c _sf _vf _pd) (Core.ReqHover req) -> do
         liftIO $ U.logs $ "reactor:got HoverRequest:" ++ show req
-        let J.TextDocumentPositionParams doc pos = req ^. J.params
-            J.Position l c = pos
+        let J.TextDocumentPositionParams _doc pos = req ^. J.params
+            J.Position _l _c' = pos
 
         let
           ht = J.Hover ms (Just range)

--- a/src/Language/Haskell/LSP/TH/DataTypesJSON.hs
+++ b/src/Language/Haskell/LSP/TH/DataTypesJSON.hs
@@ -19,7 +19,6 @@ import           Data.Hashable
 import qualified Data.Text as T
 import           Data.Text ( Text )
 import           Data.Monoid ( (<>) )
-import           Data.String
 import           System.IO ( FilePath )
 
 import Language.Haskell.LSP.TH.ClientCapabilities


### PR DESCRIPTION
The local binds warnings were cleaned up by blindly adding `_` prefixes where appropriate. Now it's clearer which are unused, and can facilitate additional cleanup.