### PR TITLE
Include microseconds in the log file

### DIFF
--- a/src/Language/Haskell/LSP/Constant.hs
+++ b/src/Language/Haskell/LSP/Constant.hs
@@ -8,5 +8,6 @@ _LOG_FORMAT :: String
 _LOG_FORMAT = "$time [$tid] - $msg"
 
 _LOG_FORMAT_DATE :: String
-_LOG_FORMAT_DATE = "%Y-%m-%d %H:%M:%S"
+-- _LOG_FORMAT_DATE = "%Y-%m-%d %H:%M:%S"
+_LOG_FORMAT_DATE = "%Y-%m-%d %H:%M:%S%Q"
 


### PR DESCRIPTION
In order to be able to understand timing.

e.g.

```
2017-08-14 16:41:35.017226217 [ThreadId 11] - ---> {"jsonrpc":"2.0","method":"textDocument/hover","params":{"textDocument":{"uri":"file:///home/alanz/mysrc/github/alanz/tide/uiPlay.hs"},"position":{"line":72,"character":28}},"id":13}
2017-08-14 16:41:35.017367193 [ThreadId 13] - reactor:got HoverRequest:RequestMessage {_jsonrpc = "2.0", _id = IdInt 13, _method = TextDocumentHover, _params = TextDocumentPositionParams {_textDocument = TextDocumentIdentifier {_uri = Uri {getUri = "file:///home/alanz/mysrc/github/alanz/tide/uiPlay.hs"}}, _position = Position {_line = 72, _character = 28}}}
2017-08-14 16:41:35.017625702 [ThreadId 14] - got request with id: Just (IdInt 13)
2017-08-14 16:41:35.017698823 [ThreadId 14] - processing request: IdInt 13
2017-08-14 16:41:35.064249183 [ThreadId 14] - dispatcherP: top of loop
2017-08-14 16:41:35.064875597 [ThreadId 12] - <--2--{"result":{"range":{"start":{"line":72,"character":27},"end":{"line":72,"character":33}},"contents":[{"value":"lexRef :: IORef (Lex State PlayLex.Token)","language":"haskell"},"`lexRef` *local*"]},"jsonrpc":"2.0","id":13}
```