### PR TITLE
Percent encode windows filepaths when creating URIs

### DIFF
--- a/src/Language/Haskell/LSP/TH/DataTypesJSON.hs
+++ b/src/Language/Haskell/LSP/TH/DataTypesJSON.hs
@@ -62,7 +62,7 @@ uriToFilePath (Uri uri)
 
 filePathToUri :: FilePath -> Uri
 filePathToUri (drive:':':rest) =
-  Uri $ T.pack $ concat ["file:///", [toLower drive], "%3a", fmap convertDelim rest]
+  Uri $ T.pack $ concat ["file:///", [toLower drive], "%3A", fmap convertDelim rest]
   where
     convertDelim '\\' = '/'
     convertDelim c = c

--- a/src/Language/Haskell/LSP/TH/DataTypesJSON.hs
+++ b/src/Language/Haskell/LSP/TH/DataTypesJSON.hs
@@ -57,11 +57,15 @@ uriToFilePath (Uri uri)
         uriDecode [] = []
 
         -- Drop leading '/' for absolute Windows paths
-        platformAdjust path@('/':drive:':':rest) = tail path
+        platformAdjust path@('/':_drive:':':_rest) = tail path
         platformAdjust path = path
 
 filePathToUri :: FilePath -> Uri
-filePathToUri file@(drive:':':rest) = Uri $ T.pack $ "file:///" ++ file
+filePathToUri (drive:':':rest) =
+  Uri $ T.pack $ concat ["file:///", [toLower drive], "%3a", fmap convertDelim rest]
+  where
+    convertDelim '\\' = '/'
+    convertDelim c = c
 filePathToUri file = Uri $ T.pack $ "file://" ++ file
 
 -- ---------------------------------------------------------------------


### PR DESCRIPTION
The file path being converted only one direction caused all changes to open a copy of the original file in VSCode for Windows.