### PR TITLE
A WorkspaceEdit should be applied from the end to the start

### DIFF
--- a/src/Language/Haskell/LSP/TH/DataTypesJSON.hs
+++ b/src/Language/Haskell/LSP/TH/DataTypesJSON.hs
@@ -31,7 +31,7 @@ import           Language.Haskell.LSP.Utility
 -- | This data type is used to host a FromJSON instance for the encoding used by
 -- elisp, where an empty list shows up as "null"
 newtype List a = List [a]
-                deriving (Show,Read,Eq,Monoid)
+                deriving (Show,Read,Eq,Monoid,Functor)
 
 instance (A.ToJSON a) => A.ToJSON (List a) where
   toJSON (List ls) = toJSON ls


### PR DESCRIPTION
Provide a function to sort the edits so that the ones applying later in the file
are at the beginning.