### PR TITLE
Don't escape semicolons after drive letters

### DIFF
--- a/src/Language/Haskell/LSP/TH/DataTypesJSON.hs
+++ b/src/Language/Haskell/LSP/TH/DataTypesJSON.hs
@@ -62,7 +62,7 @@ uriToFilePath (Uri uri)
 
 filePathToUri :: FilePath -> Uri
 filePathToUri (drive:':':rest) =
-  Uri $ T.pack $ concat ["file:///", [toLower drive], "%3A", fmap convertDelim rest]
+  Uri $ T.pack $ concat ["file:///", [toUpper drive], ":", fmap convertDelim rest]
   where
     convertDelim '\\' = '/'
     convertDelim c = c


### PR DESCRIPTION
The RFC says that semicolons may be used for special purposes in path parts of urls, and in this case no escaping is allowed. And this is consistent with Microsoft samples.

See https://github.com/haskell/haskell-ide-engine/issues/329 for discussion
See https://github.com/autozimu/LanguageClient-neovim/issues/144 for normative references and Microsoft examples of typical errors in URLs