### PR TITLE
Correct the name of the DidChangeWatchedFilesParams field.

### DIFF
--- a/src/Language/Haskell/LSP/TH/DataTypesJSON.hs
+++ b/src/Language/Haskell/LSP/TH/DataTypesJSON.hs
@@ -2366,7 +2366,7 @@ makeFieldsNoPrefix ''FileEvent
 
 data DidChangeWatchedFilesParams =
   DidChangeWatchedFilesParams
-    { _params :: List FileEvent
+    { _changes :: List FileEvent
     } deriving (Read,Show,Eq)
 
 deriveJSON lspOptions ''DidChangeWatchedFilesParams


### PR DESCRIPTION
This PR corrects the name of the `DidChangeWatchedFilesParams` field to match [the specification](https://microsoft.github.io/language-server-protocol/specification#workspace_didChangeWatchedFiles) (to wit, `changes` and not `params`).

While I never had the similar `initialized` error described in #68, this fixes the error messages I described in https://github.com/alanz/haskell-lsp/issues/68#issuecomment-374049116.