### PR TITLE
Add DiagnosticRelatedInformation

### DIFF
--- a/example/Main.hs
+++ b/example/Main.hs
@@ -8,28 +8,28 @@ module Main (main) where
 
 import           Control.Concurrent
 import           Control.Concurrent.STM.TChan
-import qualified Control.Exception as E
+import qualified Control.Exception                     as E
+import           Control.Lens
 import           Control.Monad
 import           Control.Monad.IO.Class
-import           Control.Monad.STM
 import           Control.Monad.Reader
-import qualified Data.Aeson as J
+import           Control.Monad.STM
+import qualified Data.Aeson                            as J
 import           Data.Default
-import qualified Data.HashMap.Strict as H
+import qualified Data.HashMap.Strict                   as H
 import           Data.Monoid
-import qualified Data.Text as T
-import qualified Data.Vector as V
-import qualified Language.Haskell.LSP.Control  as CTRL
-import qualified Language.Haskell.LSP.Core     as Core
+import qualified Data.Text                             as T
+import qualified Data.Vector                           as V
+import qualified Language.Haskell.LSP.Control          as CTRL
+import qualified Language.Haskell.LSP.Core             as Core
 import           Language.Haskell.LSP.Diagnostics
 import           Language.Haskell.LSP.Messages
 import qualified Language.Haskell.LSP.TH.DataTypesJSON as J
-import qualified Language.Haskell.LSP.Utility  as U
+import qualified Language.Haskell.LSP.Utility          as U
 import           Language.Haskell.LSP.VFS
 import           System.Exit
-import qualified System.Log.Logger as L
-import qualified Yi.Rope as Yi
-import Control.Lens
+import qualified System.Log.Logger                     as L
+import qualified Yi.Rope                               as Yi
 
 
 -- ---------------------------------------------------------------------
@@ -251,7 +251,7 @@ reactor lf inp = do
 
         let
           -- makeCommand only generates commands for diagnostics whose source is us
-          makeCommand (J.Diagnostic (J.Range start _) _s _c (Just "lsp-hello") _m  ) = [J.Command title cmd cmdparams]
+          makeCommand (J.Diagnostic (J.Range start _) _s _c (Just "lsp-hello") _m _l) = [J.Command title cmd cmdparams]
             where
               title = "Apply LSP hello command:" <> head (T.lines _m)
               -- NOTE: the cmd needs to be registered via the InitializeResponse message. See lspOptions above
@@ -262,7 +262,7 @@ reactor lf inp = do
                       , J.Object $ H.fromList [("start_pos",J.Object $ H.fromList [("position",    J.toJSON start)])]
                       ]
               cmdparams = Just args
-          makeCommand (J.Diagnostic _r _s _c _source _m  ) = []
+          makeCommand (J.Diagnostic _r _s _c _source _m _l) = []
         let body = J.List $ concatMap makeCommand diags
         reactorSend $ Core.makeResponseMessage req body
 
@@ -313,6 +313,7 @@ sendDiagnostics fileUri mversion = do
               Nothing  -- code
               (Just "lsp-hello") -- source
               "Example diagnostic message"
+              (J.List [])
             ]
   -- reactorSend $ J.NotificationMessage "2.0" "textDocument/publishDiagnostics" (Just r)
   publishDiagnostics 100 fileUri mversion (partitionBySource diags)

--- a/test/DiagnosticsSpec.hs
+++ b/test/DiagnosticsSpec.hs
@@ -2,13 +2,15 @@
 module DiagnosticsSpec where
 
 
-import qualified Data.Map as Map
-import qualified Data.SortedList as SL
-import           Data.Text ( Text )
+import qualified Data.Map                              as Map
+import qualified Data.SortedList                       as SL
+import           Data.Text                             (Text)
 import           Language.Haskell.LSP.Diagnostics
 import qualified Language.Haskell.LSP.TH.DataTypesJSON as J
 
 import           Test.Hspec
+
+{-# ANN module ("HLint: ignore Redundant do"  :: String) #-}
 
 -- ---------------------------------------------------------------------
 
@@ -27,10 +29,19 @@ spec = describe "Diagnostics functions" diagnosticsSpec
 -- ---------------------------------------------------------------------
 
 mkDiagnostic :: Maybe J.DiagnosticSource -> Text -> J.Diagnostic
-mkDiagnostic ms str = J.Diagnostic (J.Range (J.Position 0 1) (J.Position 3 0)) Nothing Nothing ms str
+mkDiagnostic ms str =
+  let
+    rng = J.Range (J.Position 0 1) (J.Position 3 0)
+    loc = J.Location (J.Uri "file") rng
+  in
+    J.Diagnostic rng Nothing Nothing ms str (J.List [J.DiagnosticRelatedInformation loc str])
 
 mkDiagnostic2 :: Maybe J.DiagnosticSource -> Text -> J.Diagnostic
-mkDiagnostic2 ms str = J.Diagnostic (J.Range (J.Position 4 1) (J.Position 5 0)) Nothing Nothing ms str
+mkDiagnostic2 ms str =
+  let
+    rng = J.Range (J.Position 4 1) (J.Position 5 0)
+    loc = J.Location (J.Uri "file") rng
+  in J.Diagnostic rng Nothing Nothing ms str (J.List [J.DiagnosticRelatedInformation loc str])
 
 -- ---------------------------------------------------------------------
 


### PR DESCRIPTION
## Changes
- Add `DiagnosticRelatedInformation` as per https://microsoft.github.io/language-server-protocol/specification

## Motivation
I am trying to implement this:
![image](https://user-images.githubusercontent.com/1394391/39094990-3d8ae866-467c-11e8-8a35-efb3c04bc742.png)
which I think can be a good fit for displaying Haskell compilation errors and linter suggestions.

## Drawbacks
I had to derive `Ord` for  `List` and `Location` because `Diagnostic` currently has `Ord` and it is required by how it is used.
If `Ord` for `List` and  `Location` is for some reason less than acceptable then instead of deriving `Ord` for `Diagnostic` I can manually write one that would only consider fields that existed before my change (all but `relatedInformation`).
But I personally can't see how deriving `Ord` for `List` and `Location` can be harmful. Please advice otherwise!

ping @alanz 