### PR TITLE
Make relatedInformation a Maybe List to match the spec

### DIFF
--- a/example/Main.hs
+++ b/example/Main.hs
@@ -316,7 +316,7 @@ sendDiagnostics fileUri mversion = do
               Nothing  -- code
               (Just "lsp-hello") -- source
               "Example diagnostic message"
-              (J.List [])
+              (Just (J.List []))
             ]
   -- reactorSend $ J.NotificationMessage "2.0" "textDocument/publishDiagnostics" (Just r)
   publishDiagnostics 100 fileUri mversion (partitionBySource diags)

--- a/haskell-lsp-types/src/Language/Haskell/LSP/TH/DataTypesJSON.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/TH/DataTypesJSON.hs
@@ -686,7 +686,7 @@ data Diagnostic =
     , _code               :: Maybe Text -- Note: Protocol allows Int too.
     , _source             :: Maybe DiagnosticSource
     , _message            :: Text
-    , _relatedInformation :: List DiagnosticRelatedInformation
+    , _relatedInformation :: Maybe (List DiagnosticRelatedInformation)
     } deriving (Show, Read, Eq, Ord)
 
 deriveJSON lspOptions ''Diagnostic

--- a/test/DiagnosticsSpec.hs
+++ b/test/DiagnosticsSpec.hs
@@ -34,14 +34,14 @@ mkDiagnostic ms str =
     rng = J.Range (J.Position 0 1) (J.Position 3 0)
     loc = J.Location (J.Uri "file") rng
   in
-    J.Diagnostic rng Nothing Nothing ms str (J.List [J.DiagnosticRelatedInformation loc str])
+    J.Diagnostic rng Nothing Nothing ms str (Just (J.List [J.DiagnosticRelatedInformation loc str]))
 
 mkDiagnostic2 :: Maybe J.DiagnosticSource -> Text -> J.Diagnostic
 mkDiagnostic2 ms str =
   let
     rng = J.Range (J.Position 4 1) (J.Position 5 0)
     loc = J.Location (J.Uri "file") rng
-  in J.Diagnostic rng Nothing Nothing ms str (J.List [J.DiagnosticRelatedInformation loc str])
+  in J.Diagnostic rng Nothing Nothing ms str (Just (J.List [J.DiagnosticRelatedInformation loc str]))
 
 -- ---------------------------------------------------------------------
 


### PR DESCRIPTION
The specification defines relatedInformation as optional, so this makes it a Maybe type. This fixes HIE with Visual Studio Code