### PR TITLE
Change sendFunc to take in OutMessage instead of just any ToJSON

### DIFF
--- a/example/Main.hs
+++ b/example/Main.hs
@@ -97,7 +97,7 @@ type R c a = ReaderT (Core.LspFuncs c) IO a
 
 -- ---------------------------------------------------------------------
 
-reactorSend :: (J.ToJSON a) => a -> R () ()
+reactorSend :: Core.OutMessage -> R () ()
 reactorSend msg = do
   lf <- ask
   liftIO $ Core.sendFunc lf msg
@@ -163,7 +163,7 @@ reactor lf inp = do
         let registrations = J.RegistrationParams (J.List [registration])
         rid <- nextLspReqId
 
-        reactorSend $ fmServerRegisterCapabilityRequest rid registrations
+        reactorSend $ ReqRegisterCapability $ fmServerRegisterCapabilityRequest rid registrations
 
         -- example of showMessageRequest
         let
@@ -171,7 +171,7 @@ reactor lf inp = do
                            (Just [J.MessageActionItem "option a", J.MessageActionItem "option b"])
         rid1 <- nextLspReqId
 
-        reactorSend $ fmServerShowMessageRequest rid1 params
+        reactorSend $ ReqShowMessage $ fmServerShowMessageRequest rid1 params
 
       -- -------------------------------
 

--- a/src/Language/Haskell/LSP/Core.hs
+++ b/src/Language/Haskell/LSP/Core.hs
@@ -341,6 +341,8 @@ data OutMessage = ReqHover                    J.HoverRequest
                 | ReqRename                   J.RenameRequest
                 | ReqExecuteCommand           J.ExecuteCommandRequest
                 | ReqRegisterCapability       J.RegisterCapabilityRequest
+                | ReqShowMessage              J.ShowMessageRequest
+                | ReqApplyWorkspaceEdit       J.ApplyWorkspaceEditRequest
                 -- responses
                 | RspHover                    J.HoverResponse
                 | RspCompletion               J.CompletionResponse

--- a/src/Language/Haskell/LSP/Core.hs
+++ b/src/Language/Haskell/LSP/Core.hs
@@ -181,9 +181,9 @@ data Handlers =
     , responseHandler                          :: !(Maybe (Handler J.BareResponseMessage))
 
     -- Initialization request on startup
-    , initializeRequestHandler                        :: !(Maybe (Handler J.InitializeRequest))
+    , initializeRequestHandler                 :: !(Maybe (Handler J.InitializeRequest))
     -- Will default to terminating `exitMessage` if Nothing
-    , exitNotificationHandler                              :: !(Maybe (Handler J.ExitNotification))
+    , exitNotificationHandler                  :: !(Maybe (Handler J.ExitNotification))
     }
 
 instance Default Handlers where
@@ -221,7 +221,7 @@ handlerMap _ h J.Initialized                     = hh nop $ initializedHandler h
 handlerMap _ _ J.Shutdown                        = helper shutdownRequestHandler
 handlerMap _ h J.Exit                            =
   case exitNotificationHandler h of
-    Just eh -> hh nop $ exitNotificationHandler h
+    Just _ -> hh nop $ exitNotificationHandler h
     Nothing -> \_ _ -> do
       logm $ B.pack "haskell-lsp:Got exit, exiting"
       exitSuccess


### PR DESCRIPTION
This also adds a handlers for initialisation requests and exit notifications that can be used by other packages.
We might also want to look at splitting `OutMessage` into separate types for messages from the client and messages from the server.