### PR TITLE
Split out OutMessage and change "recording" to "capturing"

### DIFF
--- a/example/Main.hs
+++ b/example/Main.hs
@@ -130,8 +130,8 @@ reactor lf inp = do
 
       -- Handle any response from a message originating at the server, such as
       -- "workspace/applyEdit"
-      -- HandlerRequest (RspFromClient rm) -> do
-      --   liftIO $ U.logs $ "reactor:got RspFromClient:" ++ show rm
+      HandlerRequest (RspFromClient rm) -> do
+        liftIO $ U.logs $ "reactor:got RspFromClient:" ++ show rm
 
       -- -------------------------------
 

--- a/example/Main.hs
+++ b/example/Main.hs
@@ -97,7 +97,7 @@ type R c a = ReaderT (Core.LspFuncs c) IO a
 
 -- ---------------------------------------------------------------------
 
-reactorSend :: (J.ToJSON a) => a -> R () ()
+reactorSend :: Core.OutMessage -> R () ()
 reactorSend msg = do
   lf <- ask
   liftIO $ Core.sendFunc lf msg
@@ -163,7 +163,7 @@ reactor lf inp = do
         let registrations = J.RegistrationParams (J.List [registration])
         rid <- nextLspReqId
 
-        reactorSend $ fmServerRegisterCapabilityRequest rid registrations
+        reactorSend $ ReqRegisterCapability $ fmServerRegisterCapabilityRequest rid registrations
 
         -- example of showMessageRequest
         let
@@ -171,7 +171,7 @@ reactor lf inp = do
                            (Just [J.MessageActionItem "option a", J.MessageActionItem "option b"])
         rid1 <- nextLspReqId
 
-        reactorSend $ fmServerShowMessageRequest rid1 params
+        reactorSend $ ReqShowMessage $ fmServerShowMessageRequest rid1 params
 
       -- -------------------------------
 

--- a/example/Main.hs
+++ b/example/Main.hs
@@ -66,7 +66,7 @@ run dispatcherProc = flip E.catches handlers $ do
 
   flip E.finally finalProc $ do
     Core.setupLogger (Just "/tmp/lsp-hello.log") [] L.DEBUG
-    CTRL.run (return (Right ()), dp) (lspHandlers rin) lspOptions Nothing Nothing
+    CTRL.run (return (Right ()), dp) (lspHandlers rin) lspOptions (Just "/tmp/lsp-hello-session.log")
 
   where
     handlers = [ E.Handler ioExcept

--- a/haskell-lsp-types/src/Language/Haskell/LSP/TH/DataTypesJSON.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/TH/DataTypesJSON.hs
@@ -296,6 +296,7 @@ instance A.FromJSON ServerMethod where
   parseJSON (A.String "workspace/applyEdit")             = return WorkspaceApplyEdit
   -- Document
   parseJSON (A.String "textDocument/publishDiagnostics") = return TextDocumentPublishDiagnostics
+  -- Cancelling
   parseJSON (A.String "$/cancelRequest")                 = return CancelRequestServer
   parseJSON _                                            = mempty
 
@@ -312,6 +313,8 @@ instance A.ToJSON ServerMethod where
   toJSON WorkspaceApplyEdit = A.String "workspace/applyEdit"
   -- Document
   toJSON TextDocumentPublishDiagnostics = A.String "textDocument/publishDiagnostics"
+  -- Cancelling
+  toJSON CancelRequestServer = A.String "$/cancelRequest"
 
 data RequestMessage m req resp =
   RequestMessage

--- a/haskell-lsp-types/src/Language/Haskell/LSP/TH/DataTypesJSON.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/TH/DataTypesJSON.hs
@@ -118,6 +118,10 @@ instance A.FromJSON LspId where
   parseJSON  (A.String  s) = return (IdString s)
   parseJSON _              = mempty
 
+instance Hashable LspId where
+  hashWithSalt salt (IdInt i) = hashWithSalt salt i
+  hashWithSalt salt (IdString s) = hashWithSalt salt s
+
 -- ---------------------------------------------------------------------
 
 -- | Id used for a response, Can be either a String or an Int, or Null. If a
@@ -139,9 +143,19 @@ instance A.FromJSON LspIdRsp where
   parseJSON  A.Null        = return IdRspNull
   parseJSON _              = mempty
 
+instance Hashable LspIdRsp where
+  hashWithSalt salt (IdRspInt i) = hashWithSalt salt i
+  hashWithSalt salt (IdRspString s) = hashWithSalt salt s
+
+-- | Converts an LspId to its LspIdRsp counterpart.
 responseId :: LspId -> LspIdRsp
 responseId (IdInt    i) = (IdRspInt i)
 responseId (IdString s) = (IdRspString s)
+
+-- | Converts an LspIdRsp to its LspId counterpart. 
+requestId :: LspIdRsp -> LspId
+requestId (IdRspInt    i) = (IdInt i)
+requestId (IdRspString s) = (IdString s)
 
 -- ---------------------------------------------------------------------
 
@@ -492,6 +506,7 @@ deriveJSON lspOptions ''CancelParams
 makeFieldsNoPrefix ''CancelParams
 
 type CancelNotification = NotificationMessage ClientMethod CancelParams
+type CancelNotificationServer = NotificationMessage ServerMethod CancelParams
 
 -- ---------------------------------------------------------------------
 

--- a/haskell-lsp-types/src/Language/Haskell/LSP/TH/DataTypesJSON.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/TH/DataTypesJSON.hs
@@ -1936,6 +1936,8 @@ makeFieldsNoPrefix ''RegistrationParams
 -- |Note: originates at the server
 type RegisterCapabilityRequest = RequestMessage ServerMethod RegistrationParams ()
 
+type RegisterCapabilityResponse = ResponseMessage ()
+
 -- -------------------------------------
 
 {-
@@ -2019,6 +2021,8 @@ deriveJSON lspOptions ''UnregistrationParams
 makeFieldsNoPrefix ''UnregistrationParams
 
 type UnregisterCapabilityRequest = RequestMessage ServerMethod UnregistrationParams ()
+
+type UnregisterCapabilityResponse = ResponseMessage ()
 
 -- ---------------------------------------------------------------------
 {-

--- a/haskell-lsp-types/src/Language/Haskell/LSP/TH/DataTypesJSON.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/TH/DataTypesJSON.hs
@@ -279,6 +279,8 @@ data ServerMethod =
   | WorkspaceApplyEdit
   -- Document
   | TextDocumentPublishDiagnostics
+  -- Cancelling
+  | CancelRequestServer  
    deriving (Eq,Ord,Read,Show)
 
 instance A.FromJSON ServerMethod where
@@ -294,6 +296,7 @@ instance A.FromJSON ServerMethod where
   parseJSON (A.String "workspace/applyEdit")             = return WorkspaceApplyEdit
   -- Document
   parseJSON (A.String "textDocument/publishDiagnostics") = return TextDocumentPublishDiagnostics
+  parseJSON (A.String "$/cancelRequest")                 = return CancelRequestServer
   parseJSON _                                            = mempty
 
 instance A.ToJSON ServerMethod where

--- a/haskell-lsp.cabal
+++ b/haskell-lsp.cabal
@@ -21,7 +21,8 @@ extra-source-files:  ChangeLog.md, README.md
 cabal-version:       >=1.10
 
 library
-  exposed-modules:     Language.Haskell.LSP.Constant
+  exposed-modules:     Language.Haskell.LSP.Capture
+                     , Language.Haskell.LSP.Constant
                      , Language.Haskell.LSP.Core
                      , Language.Haskell.LSP.Control
                      , Language.Haskell.LSP.Diagnostics

--- a/src/Language/Haskell/LSP/Capture.hs
+++ b/src/Language/Haskell/LSP/Capture.hs
@@ -7,20 +7,23 @@ import Data.Aeson
 import Data.ByteString.Lazy.Char8 as BSL
 import Data.Time.Clock
 import GHC.Generics
+import Language.Haskell.LSP.Messages
 
 data Event a = FromClient UTCTime a
              | FromServer UTCTime a
   deriving (Show, Eq, Generic, ToJSON, FromJSON)
 
-captureFromServer :: ToJSON a => a -> FilePath -> IO ()
-captureFromServer msg fp = do
+captureFromServer :: FromServerMessage -> Maybe FilePath -> IO ()
+captureFromServer _ Nothing = return ()
+captureFromServer msg (Just fp) = do
   time <- getCurrentTime
   let entry = FromServer time msg
   
   BSL.appendFile fp $ BSL.append (encode entry) "\n"
 
-captureFromClient :: ToJSON a => a -> FilePath -> IO ()
-captureFromClient msg fp = do
+captureFromClient :: FromClientMessage -> Maybe FilePath -> IO ()
+captureFromClient _ Nothing = return ()
+captureFromClient msg (Just fp) = do
   time <- getCurrentTime
   let entry = FromClient time msg
   

--- a/src/Language/Haskell/LSP/Capture.hs
+++ b/src/Language/Haskell/LSP/Capture.hs
@@ -9,8 +9,8 @@ import Data.Time.Clock
 import GHC.Generics
 import Language.Haskell.LSP.Messages
 
-data Event a = FromClient UTCTime a
-             | FromServer UTCTime a
+data Event = FromClient UTCTime FromClientMessage
+           | FromServer UTCTime FromServerMessage
   deriving (Show, Eq, Generic, ToJSON, FromJSON)
 
 captureFromServer :: FromServerMessage -> Maybe FilePath -> IO ()

--- a/src/Language/Haskell/LSP/Capture.hs
+++ b/src/Language/Haskell/LSP/Capture.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Language.Haskell.LSP.Capture (captureFromServer, captureFromClient) where
+
+import Data.Aeson
+import Data.ByteString.Lazy.Char8 as BSL
+import Data.Time.Clock
+import GHC.Generics
+
+data Event a = FromClient UTCTime a
+             | FromServer UTCTime a
+  deriving (Show, Eq, Generic, ToJSON, FromJSON)
+
+captureFromServer :: ToJSON a => a -> FilePath -> IO ()
+captureFromServer msg fp = do
+  time <- getCurrentTime
+  let entry = FromServer time msg
+  
+  BSL.appendFile fp $ BSL.append (encode entry) "\n"
+
+captureFromClient :: ToJSON a => a -> FilePath -> IO ()
+captureFromClient msg fp = do
+  time <- getCurrentTime
+  let entry = FromClient time msg
+  
+  BSL.appendFile fp $ BSL.append (encode entry) "\n"

--- a/src/Language/Haskell/LSP/Control.hs
+++ b/src/Language/Haskell/LSP/Control.hs
@@ -143,7 +143,10 @@ sendServer msgChan clientH captureFp =
   forever $ do
     msg <- atomically $ readTChan msgChan
 
-    let str = J.encode msg
+    -- We need to make sure we only send over the content of the message,
+    -- and no other tags/wrapper stuff
+    let str = J.encode $
+                J.genericToJSON (J.defaultOptions { J.sumEncoding = J.UntaggedValue }) msg
 
     let out = BSL.concat
                  [ str2lbs $ "Content-Length: " ++ show (BSL.length str)

--- a/src/Language/Haskell/LSP/Control.hs
+++ b/src/Language/Haskell/LSP/Control.hs
@@ -68,7 +68,7 @@ runWithHandles hin hout dp h o captureFp = do
   hSetEncoding  hout utf8
 
   timestamp <- formatTime defaultTimeLocale (iso8601DateFormat (Just "%H-%M-%S")) <$> getCurrentTime
-  let timestampCaptureFp = fmap (\f -> (dropExtension f) ++ timestamp ++ (takeExtension f))
+  let timestampCaptureFp = fmap (\f -> dropExtension f ++ timestamp ++ takeExtension f)
                                 captureFp
 
   cout <- atomically newTChan :: IO (TChan FromServerMessage)
@@ -150,7 +150,7 @@ sendServer msgChan clientH captureFp =
     BSL.hPut clientH out
     hFlush clientH
     logm $ B.pack "<--2--" <> str
-    
+
     captureFromServer msg captureFp
 
 -- |
@@ -158,3 +158,5 @@ sendServer msgChan clientH captureFp =
 --
 _TWO_CRLF :: String
 _TWO_CRLF = "\r\n\r\n"
+
+

--- a/src/Language/Haskell/LSP/Core.hs
+++ b/src/Language/Haskell/LSP/Core.hs
@@ -547,9 +547,13 @@ initializeRequestHandler' (_configHandler,dispatcherProc) mHandler tvarCtx req@(
           supported (Just _) = Just True
           supported Nothing   = Nothing
 
+          sync = case textDocumentSync o of
+                  Just x -> Just (J.TDSOptions x)
+                  Nothing -> Nothing
+
           capa =
             J.InitializeResponseCapabilitiesInner
-              { J._textDocumentSync                 = textDocumentSync o
+              { J._textDocumentSync                 = sync
               , J._hoverProvider                    = supported (hoverHandler h)
               , J._completionProvider               = completionProvider o
               , J._signatureHelpProvider            = signatureHelpProvider o

--- a/src/Language/Haskell/LSP/Core.hs
+++ b/src/Language/Haskell/LSP/Core.hs
@@ -178,7 +178,11 @@ data Handlers =
     , cancelNotificationHandler                :: !(Maybe (Handler J.CancelNotification))
 
     -- Responses to Request messages originated from the server
-    , responseHandler                          :: !(Maybe (Handler J.BareResponseMessage))
+    -- TODO: Properly decode response types and replace them with actual handlers
+    , responseHandler                    :: !(Maybe (Handler J.BareResponseMessage))
+    -- , registerCapabilityHandler                :: !(Maybe (Handler J.RegisterCapabilityResponse))
+    -- , unregisterCapabilityHandler              :: !(Maybe (Handler J.RegisterCapabilityResponse))
+    -- , showMessageHandler                       :: !(Maybe (Handler J.ShowMessageResponse))
 
     -- Initialization request on startup
     , initializeRequestHandler                 :: !(Maybe (Handler J.InitializeRequest))

--- a/src/Language/Haskell/LSP/Core.hs
+++ b/src/Language/Haskell/LSP/Core.hs
@@ -341,6 +341,8 @@ data OutMessage = ReqHover                    J.HoverRequest
                 | ReqRename                   J.RenameRequest
                 | ReqExecuteCommand           J.ExecuteCommandRequest
                 | ReqRegisterCapability       J.RegisterCapabilityRequest
+                | ReqShowMessage              J.ShowMessageRequest
+                | ReqApplyWorkspaceEdit       J.ApplyWorkspaceEditRequest
                 -- responses
                 | RspHover                    J.HoverResponse
                 | RspCompletion               J.CompletionResponse

--- a/src/Language/Haskell/LSP/Core.hs
+++ b/src/Language/Haskell/LSP/Core.hs
@@ -500,6 +500,9 @@ initializeRequestHandler' (_configHandler,dispatcherProc) mHandler tvarCtx req@(
 
     ctx0 <- readTVarIO tvarCtx
 
+    -- capture initialize request
+    captureFromClient (ReqInitialize req) (resCaptureFile ctx0)
+
     let rootDir = getFirst $ foldMap First [ params ^. J.rootUri  >>= J.uriToFilePath
                                            , params ^. J.rootPath <&> T.unpack ]
 

--- a/src/Language/Haskell/LSP/Core.hs
+++ b/src/Language/Haskell/LSP/Core.hs
@@ -181,9 +181,9 @@ data Handlers =
     , responseHandler                          :: !(Maybe (Handler J.BareResponseMessage))
 
     -- Initialization request on startup
-    , initializeRequestHandler                        :: !(Maybe (Handler J.InitializeRequest))
+    , initializeRequestHandler                 :: !(Maybe (Handler J.InitializeRequest))
     -- Will default to terminating `exitMessage` if Nothing
-    , exitNotificationHandler                              :: !(Maybe (Handler J.ExitNotification))
+    , exitNotificationHandler                  :: !(Maybe (Handler J.ExitNotification))
     }
 
 instance Default Handlers where
@@ -221,7 +221,7 @@ handlerMap _ h J.Initialized                     = hh nop $ initializedHandler h
 handlerMap _ _ J.Shutdown                        = helper shutdownRequestHandler
 handlerMap _ h J.Exit                            =
   case exitNotificationHandler h of
-    Just eh -> hh nop $ exitNotificationHandler h
+    Just _ -> hh nop $ exitNotificationHandler h
     Nothing -> \_ _ -> do
       logm $ B.pack "haskell-lsp:Got exit, exiting"
       exitSuccess

--- a/src/Language/Haskell/LSP/Messages.hs
+++ b/src/Language/Haskell/LSP/Messages.hs
@@ -37,6 +37,9 @@ data FromClientMessage = ReqInitialized              InitializeRequest
                        | ReqWillSaveWaitUntil        WillSaveWaitUntilTextDocumentRequest
                        -- Responses
                        | RspApplyWorkspaceEdit       ApplyWorkspaceEditResponse
+                       -- TODO: Remove this and properly decode the type of responses
+                       -- based on the id
+                       | RspFromClient               BareResponseMessage
                        -- Notifications
                        | NotInitialized                  InitializedNotification
                        | NotExit                         ExitNotification

--- a/src/Language/Haskell/LSP/Messages.hs
+++ b/src/Language/Haskell/LSP/Messages.hs
@@ -56,9 +56,7 @@ data FromClientMessage = ReqInitialized              InitializeRequest
                        | UnknownFromClientMessage        Value
 
 
-  deriving (Eq,Read,Show,Generic,FromJSON)
-instance ToJSON FromClientMessage where
-  toJSON     = genericToJSON $ defaultOptions { sumEncoding = UntaggedValue }
+  deriving (Eq,Read,Show,Generic,ToJSON,FromJSON)
 
 data FromServerMessage = ReqRegisterCapability       RegisterCapabilityRequest
                        | ReqApplyWorkspaceEdit       ApplyWorkspaceEditRequest
@@ -93,7 +91,4 @@ data FromServerMessage = ReqRegisterCapability       RegisterCapabilityRequest
                        | NotShowMessage              ShowMessageNotification
                        -- A cancel request notification is duplex!
                        | NotCancelRequestFromServer  CancelNotification
-  deriving (Eq,Read,Show,Generic,FromJSON)
-
-instance ToJSON FromServerMessage where
-  toJSON     = genericToJSON $ defaultOptions { sumEncoding = UntaggedValue }
+  deriving (Eq,Read,Show,Generic,ToJSON,FromJSON)

--- a/src/Language/Haskell/LSP/Messages.hs
+++ b/src/Language/Haskell/LSP/Messages.hs
@@ -61,6 +61,7 @@ data FromClientMessage = ReqInitialize               InitializeRequest
 -- | A wrapper around a message that originates from the server
 -- and is sent to the client.
 data FromServerMessage = ReqRegisterCapability       RegisterCapabilityRequest
+                       | ReqUnregisterCapability     UnregisterCapabilityRequest
                        | ReqApplyWorkspaceEdit       ApplyWorkspaceEditRequest
                        | ReqShowMessage              ShowMessageRequest
                        -- Responses
@@ -91,6 +92,7 @@ data FromServerMessage = ReqRegisterCapability       RegisterCapabilityRequest
                        | NotPublishDiagnostics       PublishDiagnosticsNotification
                        | NotLogMessage               LogMessageNotification
                        | NotShowMessage              ShowMessageNotification
+                       | NotTelemetry                TelemetryNotification
                        -- A cancel request notification is duplex!
                        | NotCancelRequestFromServer  CancelNotification
   deriving (Eq,Read,Show,Generic,ToJSON,FromJSON)

--- a/src/Language/Haskell/LSP/Messages.hs
+++ b/src/Language/Haskell/LSP/Messages.hs
@@ -13,7 +13,7 @@ import           Language.Haskell.LSP.TH.DataTypesJSON
 import           GHC.Generics
 import           Data.Aeson
 
-data FromClientMessage = ReqInitialized              InitializeRequest
+data FromClientMessage = ReqInitialize               InitializeRequest
                        | ReqShutdown                 ShutdownRequest
                        | ReqHover                    HoverRequest
                        | ReqCompletion               CompletionRequest

--- a/src/Language/Haskell/LSP/Messages.hs
+++ b/src/Language/Haskell/LSP/Messages.hs
@@ -94,5 +94,5 @@ data FromServerMessage = ReqRegisterCapability       RegisterCapabilityRequest
                        | NotShowMessage              ShowMessageNotification
                        | NotTelemetry                TelemetryNotification
                        -- A cancel request notification is duplex!
-                       | NotCancelRequestFromServer  CancelNotification
+                       | NotCancelRequestFromServer  CancelNotificationServer
   deriving (Eq,Read,Show,Generic,ToJSON,FromJSON)

--- a/src/Language/Haskell/LSP/Messages.hs
+++ b/src/Language/Haskell/LSP/Messages.hs
@@ -13,6 +13,8 @@ import           Language.Haskell.LSP.TH.DataTypesJSON
 import           GHC.Generics
 import           Data.Aeson
 
+-- | A wrapper around a message that originates from the client
+-- and is sent to the server.
 data FromClientMessage = ReqInitialize               InitializeRequest
                        | ReqShutdown                 ShutdownRequest
                        | ReqHover                    HoverRequest
@@ -56,6 +58,8 @@ data FromClientMessage = ReqInitialize               InitializeRequest
                        | UnknownFromClientMessage        Value
   deriving (Eq,Read,Show,Generic,ToJSON,FromJSON)
 
+-- | A wrapper around a message that originates from the server
+-- and is sent to the client.
 data FromServerMessage = ReqRegisterCapability       RegisterCapabilityRequest
                        | ReqApplyWorkspaceEdit       ApplyWorkspaceEditRequest
                        | ReqShowMessage              ShowMessageRequest

--- a/src/Language/Haskell/LSP/Messages.hs
+++ b/src/Language/Haskell/LSP/Messages.hs
@@ -54,8 +54,6 @@ data FromClientMessage = ReqInitialize               InitializeRequest
                        | NotDidChangeWatchedFiles        DidChangeWatchedFilesNotification
                        -- Unknown (The client sends something we don't understand)
                        | UnknownFromClientMessage        Value
-
-
   deriving (Eq,Read,Show,Generic,ToJSON,FromJSON)
 
 data FromServerMessage = ReqRegisterCapability       RegisterCapabilityRequest
@@ -83,7 +81,7 @@ data FromServerMessage = ReqRegisterCapability       RegisterCapabilityRequest
                        | RspExecuteCommand           ExecuteCommandResponse
                        | RspError                    ErrorResponse
                        | RspDocumentLink             DocumentLinkResponse
-                       | RspDocumentLinkResolve      DocumentLinkResolveRequest
+                       | RspDocumentLinkResolve      DocumentLinkResolveResponse
                        | RspWillSaveWaitUntil        WillSaveWaitUntilTextDocumentResponse
                        -- Notifications
                        | NotPublishDiagnostics       PublishDiagnosticsNotification

--- a/src/Language/Haskell/LSP/Messages.hs
+++ b/src/Language/Haskell/LSP/Messages.hs
@@ -1,6 +1,91 @@
-module Language.Haskell.LSP.Messages
-  (
-    module Language.Haskell.LSP.TH.Messages
-  ) where
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
 
-import Language.Haskell.LSP.TH.Messages
+module Language.Haskell.LSP.Messages
+  ( module Language.Haskell.LSP.TH.Messages
+  , FromClientMessage(..)
+  , FromServerMessage(..)
+  )
+where
+
+import           Language.Haskell.LSP.TH.Messages
+import           Language.Haskell.LSP.TH.DataTypesJSON
+import           GHC.Generics
+import           Data.Aeson
+
+data FromClientMessage = ReqInitialized              InitializeRequest
+                       | ReqShutdown                 ShutdownRequest
+                       | ReqHover                    HoverRequest
+                       | ReqCompletion               CompletionRequest
+                       | ReqCompletionItemResolve    CompletionItemResolveRequest
+                       | ReqSignatureHelp            SignatureHelpRequest
+                       | ReqDefinition               DefinitionRequest
+                       | ReqFindReferences           ReferencesRequest
+                       | ReqDocumentHighlights       DocumentHighlightRequest
+                       | ReqDocumentSymbols          DocumentSymbolRequest
+                       | ReqWorkspaceSymbols         WorkspaceSymbolRequest
+                       | ReqCodeAction               CodeActionRequest
+                       | ReqCodeLens                 CodeLensRequest
+                       | ReqCodeLensResolve          CodeLensResolveRequest
+                       | ReqDocumentFormatting       DocumentFormattingRequest
+                       | ReqDocumentRangeFormatting  DocumentRangeFormattingRequest
+                       | ReqDocumentOnTypeFormatting DocumentOnTypeFormattingRequest
+                       | ReqRename                   RenameRequest
+                       | ReqExecuteCommand           ExecuteCommandRequest
+                       | ReqDocumentLink             DocumentLinkRequest
+                       | ReqDocumentLinkResolve      DocumentLinkResolveRequest
+                       | ReqWillSaveWaitUntil        WillSaveWaitUntilTextDocumentRequest
+                       -- Responses
+                       | RspApplyWorkspaceEdit       ApplyWorkspaceEditResponse
+                       -- Notifications
+                       | NotInitialized                  InitializedNotification
+                       | NotExit                         ExitNotification
+                       -- A cancel request notification is duplex!
+                       | NotCancelRequestFromClient      CancelNotification
+                       | NotDidChangeConfiguration       DidChangeConfigurationNotification
+                       | NotDidOpenTextDocument          DidOpenTextDocumentNotification
+                       | NotDidChangeTextDocument        DidChangeTextDocumentNotification
+                       | NotDidCloseTextDocument         DidCloseTextDocumentNotification
+                       | NotWillSaveTextDocument         WillSaveTextDocumentNotification
+                       | NotDidSaveTextDocument          DidSaveTextDocumentNotification
+                       | NotDidChangeWatchedFiles        DidChangeWatchedFilesNotification
+                       -- Unknown (The client sends something we don't understand)
+                       | UnknownFromClientMessage        Value
+
+
+  deriving (Eq,Read,Show,Generic,ToJSON,FromJSON)
+
+data FromServerMessage = ReqRegisterCapability       RegisterCapabilityRequest
+                       | ReqApplyWorkspaceEdit       ApplyWorkspaceEditRequest
+                       | ReqShowMessage              ShowMessageRequest
+                       -- Responses
+                       | RspInitialize               InitializeResponse
+                       | RspShutdown                 ShutdownResponse
+                       | RspHover                    HoverResponse
+                       | RspCompletion               CompletionResponse
+                       | RspCompletionItemResolve    CompletionItemResolveResponse
+                       | RspSignatureHelp            SignatureHelpResponse
+                       | RspDefinition               DefinitionResponse
+                       | RspFindReferences           ReferencesResponse
+                       | RspDocumentHighlights       DocumentHighlightsResponse
+                       | RspDocumentSymbols          DocumentSymbolsResponse
+                       | RspWorkspaceSymbols         WorkspaceSymbolsResponse
+                       | RspCodeAction               CodeActionResponse
+                       | RspCodeLens                 CodeLensResponse
+                       | RspCodeLensResolve          CodeLensResolveResponse
+                       | RspDocumentFormatting       DocumentFormattingResponse
+                       | RspDocumentRangeFormatting  DocumentRangeFormattingResponse
+                       | RspDocumentOnTypeFormatting DocumentOnTypeFormattingResponse
+                       | RspRename                   RenameResponse
+                       | RspExecuteCommand           ExecuteCommandResponse
+                       | RspError                    ErrorResponse
+                       | RspDocumentLink             DocumentLinkResponse
+                       | RspDocumentLinkResolve      DocumentLinkResolveRequest
+                       | RspWillSaveWaitUntil        WillSaveWaitUntilTextDocumentResponse
+                       -- Notifications
+                       | NotPublishDiagnostics       PublishDiagnosticsNotification
+                       | NotLogMessage               LogMessageNotification
+                       | NotShowMessage              ShowMessageNotification
+                       -- A cancel request notification is duplex!
+                       | NotCancelRequestFromServer  CancelNotification
+  deriving (Eq,Read,Show,Generic,ToJSON,FromJSON)

--- a/src/Language/Haskell/LSP/Messages.hs
+++ b/src/Language/Haskell/LSP/Messages.hs
@@ -56,7 +56,9 @@ data FromClientMessage = ReqInitialized              InitializeRequest
                        | UnknownFromClientMessage        Value
 
 
-  deriving (Eq,Read,Show,Generic,ToJSON,FromJSON)
+  deriving (Eq,Read,Show,Generic,FromJSON)
+instance ToJSON FromClientMessage where
+  toJSON     = genericToJSON $ defaultOptions { sumEncoding = UntaggedValue }
 
 data FromServerMessage = ReqRegisterCapability       RegisterCapabilityRequest
                        | ReqApplyWorkspaceEdit       ApplyWorkspaceEditRequest
@@ -91,4 +93,7 @@ data FromServerMessage = ReqRegisterCapability       RegisterCapabilityRequest
                        | NotShowMessage              ShowMessageNotification
                        -- A cancel request notification is duplex!
                        | NotCancelRequestFromServer  CancelNotification
-  deriving (Eq,Read,Show,Generic,ToJSON,FromJSON)
+  deriving (Eq,Read,Show,Generic,FromJSON)
+
+instance ToJSON FromServerMessage where
+  toJSON     = genericToJSON $ defaultOptions { sumEncoding = UntaggedValue }


### PR DESCRIPTION
`OutMessage` now consists of two separate data types for messages that originate from the client and messages that originate from the server.

Recording is now called capturing and encodes message types based on these new types. It now saves the session to one file with timestamped messages and type information.