### PR TITLE
Don't sort DocumentContentChangeEvents when applying changes

### DIFF
--- a/src/Language/Haskell/LSP/VFS.hs
+++ b/src/Language/Haskell/LSP/VFS.hs
@@ -18,8 +18,8 @@ module Language.Haskell.LSP.VFS
   , closeVFS
 
   -- * for tests
+  , applyChanges
   , applyChange
-  , sortChanges
   , deleteChars , addChars
   , changeChars
   , yiSplitAt
@@ -89,12 +89,11 @@ data TextDocumentContentChangeEvent =
     } deriving (Read,Show,Eq)
 -}
 
--- | Apply the list of changes, in descending order of range. Assuming no overlaps.
+-- | Apply the list of changes.
+-- Changes should be applied in the order that they are
+-- received from the client.
 applyChanges :: Yi.YiString -> [J.TextDocumentContentChangeEvent] -> Yi.YiString
-applyChanges str changes' = r
-  where
-    changes = sortChanges changes'
-    r = foldl' applyChange str changes
+applyChanges = foldl' applyChange
 
 -- ---------------------------------------------------------------------
 
@@ -175,17 +174,5 @@ yiSplitAt l c str = (before,after)
     (b,a) = Yi.splitAtLine l str
     before = Yi.concat [b,Yi.take c a]
     after = Yi.drop c a
-
-
--- ---------------------------------------------------------------------
-
-sortChanges :: [J.TextDocumentContentChangeEvent] -> [J.TextDocumentContentChangeEvent]
-sortChanges changes = changes'
-  where
-    myComp (J.TextDocumentContentChangeEvent (Just r1) _ _)
-           (J.TextDocumentContentChangeEvent (Just r2) _ _)
-      = compare r2 r1 -- want descending order
-    myComp _ _ = EQ
-    changes' = sortBy myComp changes
 
 -- ---------------------------------------------------------------------

--- a/test/VspSpec.hs
+++ b/test/VspSpec.hs
@@ -32,17 +32,23 @@ mkRange ls cs le ce = Just $ J.Range (J.Position ls cs) (J.Position le ce)
 
 vspSpec :: Spec
 vspSpec = do
-  describe "sorts changes" $ do
-    it "sorts changes that all have ranges" $ do
-      let
-        unsorted =
-          [ (J.TextDocumentContentChangeEvent (mkRange 1 0 2 0) Nothing "")
-          , (J.TextDocumentContentChangeEvent (mkRange 2 0 3 0) Nothing "")
-          ]
-      (sortChanges unsorted) `shouldBe`
-          [ (J.TextDocumentContentChangeEvent (mkRange 2 0 3 0) Nothing "")
-          , (J.TextDocumentContentChangeEvent (mkRange 1 0 2 0) Nothing "")
-          ]
+  describe "applys changes in order" $ do
+    it "handles vscode style undos" $ do
+      let orig = "abc"
+          changes =
+            [ J.TextDocumentContentChangeEvent (mkRange 0 2 0 3) Nothing ""
+            , J.TextDocumentContentChangeEvent (mkRange 0 1 0 2) Nothing ""
+            , J.TextDocumentContentChangeEvent (mkRange 0 0 0 1) Nothing ""
+            ]
+      applyChanges orig changes `shouldBe` ""
+    it "handles vscode style redos" $ do
+      let orig = ""
+          changes =
+            [ J.TextDocumentContentChangeEvent (mkRange 0 1 0 1) Nothing "a"
+            , J.TextDocumentContentChangeEvent (mkRange 0 2 0 2) Nothing "b"
+            , J.TextDocumentContentChangeEvent (mkRange 0 3 0 3) Nothing "c"
+            ]
+      applyChanges orig changes `shouldBe` "abc"
 
     -- ---------------------------------
 


### PR DESCRIPTION
This works with VS Code's behaviour for undos and redos. See https://github.com/haskell/haskell-ide-engine/pull/603