### PR TITLE
Add new Code Action types in v3.8

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Revision history for haskell-lsp
 
+## 0.4.0.0
+
+* CodeAction support as per v3.8 of the specification.
+
 ## 0.3.0.0
 
 * Handle TextDocumentSync fallbacks with new TDS type.

--- a/example/Main.hs
+++ b/example/Main.hs
@@ -266,8 +266,9 @@ reactor lf inp = do
                       ]
               cmdparams = Just args
           makeCommand (J.Diagnostic _r _s _c _source _m _l) = []
-        let body = J.List $ concatMap makeCommand diags
-        reactorSend $ RspCodeAction $ Core.makeResponseMessage req body
+        let body = Just $ J.List $ map J.CommandOrCodeActionCommand $ concatMap makeCommand diags
+            rsp = Core.makeResponseMessage req body
+        reactorSend $ RspCodeAction rsp
 
       -- -------------------------------
 

--- a/haskell-lsp-types/src/Language/Haskell/LSP/TH/ClientCapabilities.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/TH/ClientCapabilities.hs
@@ -506,8 +506,8 @@ $(deriveJSON lspOptions ''CodeActionLiteralSupport)
 
 data CodeActionClientCapabilities =
   CodeActionClientCapabilities
-    { _dynamicRegistration     :: Maybe Bool -- ^ Whether code action supports dynamic registration.
-    , codeActionLiteralSupport :: Maybe CodeActionLiteralSupport -- ^ The client support code action literals as a valid response
+    { _dynamicRegistration      :: Maybe Bool -- ^ Whether code action supports dynamic registration.
+    , _codeActionLiteralSupport :: Maybe CodeActionLiteralSupport -- ^ The client support code action literals as a valid response
                                                                  -- of the `textDocument/codeAction` request.
                                                                  -- Since 3.8.0
     } deriving (Show, Read, Eq)

--- a/haskell-lsp-types/src/Language/Haskell/LSP/TH/ClientCapabilities.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/TH/ClientCapabilities.hs
@@ -6,6 +6,8 @@ module Language.Haskell.LSP.TH.ClientCapabilities where
 import           Data.Aeson.TH
 import qualified Data.Aeson as A
 import Language.Haskell.LSP.TH.Constants
+import Language.Haskell.LSP.TH.CodeAction
+import Language.Haskell.LSP.TH.List
 import Data.Default
 
 -- ---------------------------------------------------------------------
@@ -488,9 +490,26 @@ $(deriveJSON lspOptions ''DefinitionClientCapabilities)
 
 -- -------------------------------------
 
+data CodeActionKindValueSet =
+  CodeActionKindValueSet
+   { _valueSet :: List CodeActionKind
+   } deriving (Show, Read, Eq)
+
+$(deriveJSON lspOptions ''CodeActionKindValueSet)
+
+data CodeActionLiteralSupport =
+  CodeActionLiteralSupport
+    { _codeActionKind :: CodeActionKindValueSet -- ^ The code action kind is support with the following value set.
+    } deriving (Show, Read, Eq)
+
+$(deriveJSON lspOptions ''CodeActionLiteralSupport)
+
 data CodeActionClientCapabilities =
   CodeActionClientCapabilities
     { _dynamicRegistration     :: Maybe Bool -- ^ Whether code action supports dynamic registration.
+    , codeActionLiteralSupport :: Maybe CodeActionLiteralSupport -- ^ The client support code action literals as a valid response
+                                                                 -- of the `textDocument/codeAction` request.
+                                                                 -- Since 3.8.0
     } deriving (Show, Read, Eq)
 
 $(deriveJSON lspOptions ''CodeActionClientCapabilities)

--- a/haskell-lsp-types/src/Language/Haskell/LSP/TH/CodeAction.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/TH/CodeAction.hs
@@ -4,10 +4,10 @@
 module Language.Haskell.LSP.TH.CodeAction where
 
 import           Control.Applicative
-import qualified Data.Aeson                                 as A
+import qualified Data.Aeson                    as A
 import           Data.Aeson.TH
 import           Data.Aeson.Types
-import           Data.Text                                  (Text)
+import           Data.Text                      ( Text )
 import           Language.Haskell.LSP.TH.Command
 import           Language.Haskell.LSP.TH.Constants
 import           Language.Haskell.LSP.TH.Diagnostic
@@ -16,7 +16,7 @@ import           Language.Haskell.LSP.TH.Location
 import           Language.Haskell.LSP.TH.Message
 import           Language.Haskell.LSP.TH.TextDocumentIdentifier
 import           Language.Haskell.LSP.TH.WorkspaceEdit
-  
+
 
 {-
 Code Action Request
@@ -218,26 +218,29 @@ data CodeActionKind = CodeActionQuickFix
                     | CodeActionRefactorRewrite
                     | CodeActionSource
                     | CodeActionSourceOrganizeImports
+                    | CodeActionUnknown Text
   deriving (Read,Show,Eq)
 
 instance ToJSON CodeActionKind where
-  toJSON CodeActionQuickFix = String "quickfix"
-  toJSON CodeActionRefactor = String "refactor"
-  toJSON CodeActionRefactorExtract = String "refactor.extract"
-  toJSON CodeActionRefactorInline = String "refactor.inline"
-  toJSON CodeActionRefactorRewrite = String "refactor.rewrite"
-  toJSON CodeActionSource = String "source"
-  toJSON CodeActionSourceOrganizeImports = String "source.organizeImports"
+  toJSON CodeActionQuickFix                   = String "quickfix"
+  toJSON CodeActionRefactor                   = String "refactor"
+  toJSON CodeActionRefactorExtract            = String "refactor.extract"
+  toJSON CodeActionRefactorInline             = String "refactor.inline"
+  toJSON CodeActionRefactorRewrite            = String "refactor.rewrite"
+  toJSON CodeActionSource                     = String "source"
+  toJSON CodeActionSourceOrganizeImports      = String "source.organizeImports"
+  toJSON (CodeActionUnknown s)                = String s
 
 instance FromJSON CodeActionKind where
-  parseJSON (String "quickfix") = return CodeActionQuickFix
-  parseJSON (String "refactor") = return CodeActionRefactor
-  parseJSON (String "refactor.extract") = return CodeActionRefactorExtract
-  parseJSON (String "refactor.inline") = return CodeActionRefactorInline
-  parseJSON (String "refactor.rewrite") = return CodeActionRefactorRewrite
-  parseJSON (String "source") = return CodeActionSource
-  parseJSON (String "source.organizeImports") = return CodeActionSourceOrganizeImports
-  parseJSON _ = mempty
+  parseJSON (String "quickfix")               = pure CodeActionQuickFix
+  parseJSON (String "refactor")               = pure CodeActionRefactor
+  parseJSON (String "refactor.extract")       = pure CodeActionRefactorExtract
+  parseJSON (String "refactor.inline")        = pure CodeActionRefactorInline
+  parseJSON (String "refactor.rewrite")       = pure CodeActionRefactorRewrite
+  parseJSON (String "source")                 = pure CodeActionSource
+  parseJSON (String "source.organizeImports") = pure CodeActionSourceOrganizeImports
+  parseJSON (String s)                        = pure (CodeActionUnknown s)
+  parseJSON _                                 = mempty
 
 data CodeActionContext =
   CodeActionContext
@@ -280,9 +283,9 @@ data CommandOrCodeAction = CommandOrCodeActionCommand Command
   deriving (Read,Show,Eq)
 
 instance FromJSON CommandOrCodeAction where
-  parseJSON x = CommandOrCodeActionCommand <$> parseJSON x 
+  parseJSON x = CommandOrCodeActionCommand <$> parseJSON x
               <|> CommandOrCodeActionCodeAction <$> parseJSON x
-    
+
 instance ToJSON CommandOrCodeAction where
   toJSON (CommandOrCodeActionCommand x) = toJSON x
   toJSON (CommandOrCodeActionCodeAction x) = toJSON x

--- a/haskell-lsp-types/src/Language/Haskell/LSP/TH/CodeAction.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/TH/CodeAction.hs
@@ -7,6 +7,7 @@ import           Control.Applicative
 import qualified Data.Aeson                                 as A
 import           Data.Aeson.TH
 import           Data.Aeson.Types
+import           Data.Text                                  (Text)
 import           Language.Haskell.LSP.TH.Command
 import           Language.Haskell.LSP.TH.Constants
 import           Language.Haskell.LSP.TH.Diagnostic
@@ -14,57 +15,238 @@ import           Language.Haskell.LSP.TH.List
 import           Language.Haskell.LSP.TH.Location
 import           Language.Haskell.LSP.TH.Message
 import           Language.Haskell.LSP.TH.TextDocumentIdentifier
+import           Language.Haskell.LSP.TH.WorkspaceEdit
   
 
 {-
 Code Action Request
+
 https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md#code-action-request
-The code action request is sent from the client to the server to compute
-commands for a given text document and range. The request is triggered when the
-user moves the cursor into a problem marker in the editor or presses the
-lightbulb associated with a marker.
+
+The code action request is sent from the client to the server tocompute commands
+for a given text document and range. These commands are typically code fixes to
+either fix problems or to beautify/refactor code. The result of a
+textDocument/codeAction request is an array of Command literals which are
+typically presented in the user interface. When the command is selected the
+server should be contacted again (via the workspace/executeCommand) request to
+execute the command.
+
+Since version 3.8.0: support for CodeAction litarals to enable the following
+scenarios:
+
+the ability to directly return a workspace edit from e code action request. This
+avoids having another server roundtrip to execute an actual code action. However
+server providers should be aware that if the code action is expensive to compute
+or the edits are huge it might still be beneficial if the result is imply a
+command and the actual edit is only computed when needed. the ability to group
+code actions using a kind. Clients are allowed to ignore that information.
+However it allows them to better group code action for example into
+corresponding menus (e.g. all refactor code actions into a refactor menu).
+Clients need to announce there support code action literals and code action
+kinds via the corresponding client capability
+textDocument.codeAction.codeActionLiteralSupport.
+
 Request
+
     method: 'textDocument/codeAction'
     params: CodeActionParams defined as follows:
+
 /**
  * Params for the CodeActionRequest
  */
 interface CodeActionParams {
-    /**
-     * The document in which the command was invoked.
-     */
-    textDocument: TextDocumentIdentifier;
-    /**
-     * The range for which the command was invoked.
-     */
-    range: Range;
-    /**
-     * Context carrying additional information.
-     */
-    context: CodeActionContext;
+	/**
+	 * The document in which the command was invoked.
+	 */
+	textDocument: TextDocumentIdentifier;
+
+	/**
+	 * The range for which the command was invoked.
+	 */
+	range: Range;
+
+	/**
+	 * Context carrying additional information.
+	 */
+	context: CodeActionContext;
 }
+
+/**
+ * The kind of a code action.
+ *
+ * Kinds are a hierarchical list of identifiers separated by `.`, e.g. `"refactor.extract.function"`.
+ *
+ * The set of kinds is open and client needs to announce the kinds it supports to the server during
+ * initialization.
+ */
+export type CodeActionKind = string;
+
+/**
+ * A set of predefined code action kinds
+ */
+export namespace CodeActionKind {
+	/**
+	 * Base kind for quickfix actions: 'quickfix'
+	 */
+	export const QuickFix: CodeActionKind = 'quickfix';
+
+	/**
+	 * Base kind for refactoring actions: 'refactor'
+	 */
+	export const Refactor: CodeActionKind = 'refactor';
+
+	/**
+	 * Base kind for refactoring extraction actions: 'refactor.extract'
+	 *
+	 * Example extract actions:
+	 *
+	 * - Extract method
+	 * - Extract function
+	 * - Extract variable
+	 * - Extract interface from class
+	 * - ...
+	 */
+	export const RefactorExtract: CodeActionKind = 'refactor.extract';
+
+	/**
+	 * Base kind for refactoring inline actions: 'refactor.inline'
+	 *
+	 * Example inline actions:
+	 *
+	 * - Inline function
+	 * - Inline variable
+	 * - Inline constant
+	 * - ...
+	 */
+	export const RefactorInline: CodeActionKind = 'refactor.inline';
+
+	/**
+	 * Base kind for refactoring rewrite actions: 'refactor.rewrite'
+	 *
+	 * Example rewrite actions:
+	 *
+	 * - Convert JavaScript function to class
+	 * - Add or remove parameter
+	 * - Encapsulate field
+	 * - Make method static
+	 * - Move method to base class
+	 * - ...
+	 */
+	export const RefactorRewrite: CodeActionKind = 'refactor.rewrite';
+
+	/**
+	 * Base kind for source actions: `source`
+	 *
+	 * Source code actions apply to the entire file.
+	 */
+	export const Source: CodeActionKind = 'source';
+
+	/**
+	 * Base kind for an organize imports source action: `source.organizeImports`
+	 */
+	export const SourceOrganizeImports: CodeActionKind = 'source.organizeImports';
+}
+
 /**
  * Contains additional diagnostic information about the context in which
  * a code action is run.
  */
 interface CodeActionContext {
-    /**
-     * An array of diagnostics.
-     */
-    diagnostics: Diagnostic[];
+	/**
+	 * An array of diagnostics.
+	 */
+	diagnostics: Diagnostic[];
+
+	/**
+	 * Requested kind of actions to return.
+	 *
+	 * Actions not of this kind are filtered out by the client before being shown. So servers
+	 * can omit computing them.
+	 */
+	only?: CodeActionKind[];
 }
+
 Response
-    result: Command[] defined as follows:
+
+    result: (Command | CodeAction)[] | null where CodeAction is defined as follows:
+        /**
+    * A code action represents a change that can be performed in code, e.g. to fix a problem or
+    * to refactor code.
+    *
+    * A CodeAction must set either `edit` and/or a `command`. If both are supplied, the `edit` is applied first, then the `command` is executed.
+    */
+    export interface CodeAction {
+
+        /**
+        * A short, human-readable, title for this code action.
+        */
+        title: string;
+
+        /**
+        * The kind of the code action.
+        *
+        * Used to filter code actions.
+        */
+        kind?: CodeActionKind;
+
+        /**
+        * The diagnostics that this code action resolves.
+        */
+        diagnostics?: Diagnostic[];
+
+        /**
+        * The workspace edit this code action performs.
+        */
+        edit?: WorkspaceEdit;
+
+        /**
+        * A command this code action executes. If a code action
+        * provides an edit and a command, first the edit is
+        * executed and then the command.
+        */
+        command?: Command;
+    }
     error: code and message set in case an exception happens during the code
            action request.
+
 -}
+
+data CodeActionKind = CodeActionQuickFix
+                    | CodeActionRefactor
+                    | CodeActionRefactorExtract
+                    | CodeActionRefactorInline
+                    | CodeActionRefactorRewrite
+                    | CodeActionSource
+                    | CodeActionSourceOrganizeImports
+  deriving (Read,Show,Eq)
+
+instance ToJSON CodeActionKind where
+  toJSON CodeActionQuickFix = String "quickfix"
+  toJSON CodeActionRefactor = String "refactor"
+  toJSON CodeActionRefactorExtract = String "refactor.extract"
+  toJSON CodeActionRefactorInline = String "refactor.inline"
+  toJSON CodeActionRefactorRewrite = String "refactor.rewrite"
+  toJSON CodeActionSource = String "source"
+  toJSON CodeActionSourceOrganizeImports = String "source.organizeImports"
+
+instance FromJSON CodeActionKind where
+  parseJSON (String "quickfix") = return CodeActionQuickFix
+  parseJSON (String "refactor") = return CodeActionRefactor
+  parseJSON (String "refactor.extract") = return CodeActionRefactorExtract
+  parseJSON (String "refactor.inline") = return CodeActionRefactorInline
+  parseJSON (String "refactor.rewrite") = return CodeActionRefactorRewrite
+  parseJSON (String "source") = return CodeActionSource
+  parseJSON (String "source.organizeImports") = return CodeActionSourceOrganizeImports
+  parseJSON _ = mempty
 
 data CodeActionContext =
   CodeActionContext
     { _diagnostics :: List Diagnostic
+    , only         :: Maybe (List CodeActionKind)
     } deriving (Read,Show,Eq)
 
 deriveJSON lspOptions ''CodeActionContext
+
 
 data CodeActionParams =
   CodeActionParams
@@ -75,6 +257,35 @@ data CodeActionParams =
 
 deriveJSON lspOptions ''CodeActionParams
 
+data CodeAction =
+  -- | A code action represents a change that can be performed in code, e.g. to fix a problem or
+  -- to refactor code.
+  --
+  -- A CodeAction must set either '_edit' and/or a '_command'. If both are supplied,
+  -- the '_edit' is applied first, then the '_command' is executed.
+  CodeAction
+    { _title       :: Text -- ^ A short, human-readable, title for this code action.
+    , _kind        :: Maybe CodeActionKind -- ^ The kind of the code action. Used to filter code actions.
+    , _diagnostics :: Maybe (List Diagnostic) -- ^ The diagnostics that this code action resolves.
+    , _edit        :: Maybe WorkspaceEdit -- ^ The workspace edit this code action performs.
+    , _command     :: Maybe Command -- ^ A command this code action executes. If a code action
+                                    -- provides an edit and a command, first the edit is
+                                    -- executed and then the command.
+    } deriving (Read,Show,Eq)
 
-type CodeActionRequest  = RequestMessage ClientMethod CodeActionParams (List Command)
-type CodeActionResponse = ResponseMessage (List Command)
+deriveJSON lspOptions ''CodeAction
+
+data CommandOrCodeAction = CommandOrCodeActionCommand Command
+                         | CommandOrCodeActionCodeAction CodeAction
+  deriving (Read,Show,Eq)
+
+instance FromJSON CommandOrCodeAction where
+  parseJSON x = CommandOrCodeActionCommand <$> parseJSON x 
+              <|> CommandOrCodeActionCodeAction <$> parseJSON x
+    
+instance ToJSON CommandOrCodeAction where
+  toJSON (CommandOrCodeActionCommand x) = toJSON x
+  toJSON (CommandOrCodeActionCodeAction x) = toJSON x
+
+type CodeActionRequest  = RequestMessage ClientMethod CodeActionParams (Maybe (List CommandOrCodeAction))
+type CodeActionResponse = ResponseMessage (Maybe (List CommandOrCodeAction))

--- a/haskell-lsp-types/src/Language/Haskell/LSP/TH/DataTypesJSON.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/TH/DataTypesJSON.hs
@@ -3357,6 +3357,7 @@ makeFieldsNoPrefix ''Location
 -- CodeActions
 makeFieldsNoPrefix ''CodeActionContext
 makeFieldsNoPrefix ''CodeActionParams
+makeFieldsNoPrefix ''CodeAction
 
 -- WorkspaceEdit
 makeFieldsNoPrefix ''TextEdit

--- a/haskell-lsp.cabal
+++ b/haskell-lsp.cabal
@@ -28,6 +28,7 @@ library
                      , Language.Haskell.LSP.Diagnostics
                      , Language.Haskell.LSP.Messages
                      , Language.Haskell.LSP.Types
+                     , Language.Haskell.LSP.Types.Capabilities
                      , Language.Haskell.LSP.Utility
                      , Language.Haskell.LSP.VFS
   -- other-modules:

--- a/haskell-lsp.cabal
+++ b/haskell-lsp.cabal
@@ -1,5 +1,5 @@
 name:                haskell-lsp
-version:             0.3.0.0
+version:             0.4.0.0
 synopsis:            Haskell library for the Microsoft Language Server Protocol
 
 description:         An implementation of the types, and basic message server to

--- a/src/Language/Haskell/LSP/Types/Capabilities.hs
+++ b/src/Language/Haskell/LSP/Types/Capabilities.hs
@@ -1,0 +1,6 @@
+module Language.Haskell.LSP.Types.Capabilities
+  (
+    module Language.Haskell.LSP.TH.ClientCapabilities
+  ) where
+
+import Language.Haskell.LSP.TH.ClientCapabilities


### PR DESCRIPTION
In 3.8.0 new [code action stuff was added](https://microsoft.github.io/language-server-protocol/specification#textDocument_codeAction).
There's now a fully fledged `CodeAction` type that contains more information like a name and kind (e.g. refactoring, quick-fix, organise imports etc.).
You can now also return a WorkspaceEditRequest immediately instead of a command, skipping the roundtrip from the client to the server.