### PR TITLE
Fix platformAwareUriToFilePath for empty paths

### DIFF
--- a/haskell-lsp-types/src/Language/Haskell/LSP/TH/Uri.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/TH/Uri.hs
@@ -33,7 +33,7 @@ platformAwareUriToFilePath systemOS (Uri uri) = do
 
 platformAdjustFromUriPath :: SystemOS -> String -> FilePath
 platformAdjustFromUriPath systemOS srcPath =
-  if systemOS /= windowsOS then srcPath
+  if systemOS /= windowsOS || null srcPath then srcPath
     else let
       firstSegment:rest = (FPP.splitDirectories . tail) srcPath  -- Drop leading '/' for absolute Windows paths
       drive = if FPW.isDrive firstSegment then FPW.addTrailingPathSeparator firstSegment else firstSegment


### PR DESCRIPTION
This PR makes `platformAdjustFromUriPath` act as `id` for empty paths.

Ref https://github.com/haskell/haskell-ide-engine/issues/713
Some tests in `test/unit/JsonSpec` fail when empty strings are passed to `platformAwareUriToFilePath`, then `splitDirectories` return empty list which then fails to pattern match on `firstSegment:rest`.

I'm not sure if empty string is a valid value for `srcPath` or property tests should be altered to produce non-empty strings, though. 