### PR TITLE
Export constructor for LSPVersion

### DIFF
--- a/haskell-lsp.cabal
+++ b/haskell-lsp.cabal
@@ -93,6 +93,7 @@ test-suite haskell-lsp-test
   hs-source-dirs:      test
   main-is:             Main.hs
   other-modules:       Spec
+                       CapabilitiesSpec
                        DiagnosticsSpec
                        MethodSpec
                        URIFilePathSpec

--- a/src/Language/Haskell/LSP/Types/Capabilities.hs
+++ b/src/Language/Haskell/LSP/Types/Capabilities.hs
@@ -2,7 +2,7 @@ module Language.Haskell.LSP.Types.Capabilities
   (
     module Language.Haskell.LSP.TH.ClientCapabilities
   , fullCaps
-  , LSPVersion
+  , LSPVersion(..)
   , capsForVersion
   ) where
 

--- a/test/CapabilitiesSpec.hs
+++ b/test/CapabilitiesSpec.hs
@@ -1,0 +1,15 @@
+module CapabilitiesSpec where
+
+import Language.Haskell.LSP.Types.Capabilities
+import Test.Hspec
+
+spec :: Spec
+spec = describe "capabilities" $ do
+  it "gives 3.10 capabilities" $
+    let ClientCapabilities _ (Just tdcs) _ = capsForVersion (LSPVersion 3 10)
+        Just (DocumentSymbolClientCapabilities _ _ mHierarchical) = _documentSymbol tdcs
+      in mHierarchical `shouldBe` Just True
+  it "gives pre 3.10 capabilities" $
+      let ClientCapabilities _ (Just tdcs) _ = capsForVersion (LSPVersion 3 9)
+          Just (DocumentSymbolClientCapabilities _ _ mHierarchical) = _documentSymbol tdcs
+        in mHierarchical `shouldBe` Nothing


### PR DESCRIPTION
No need to make a release just for this, can go in with the next one