### PR TITLE
Split out the Lens module

### DIFF
--- a/example/Main.hs
+++ b/example/Main.hs
@@ -27,6 +27,7 @@ import qualified Language.Haskell.LSP.Core             as Core
 import           Language.Haskell.LSP.Diagnostics
 import           Language.Haskell.LSP.Messages
 import qualified Language.Haskell.LSP.Types            as J
+import qualified Language.Haskell.LSP.Types.Lens       as J
 import qualified Language.Haskell.LSP.Utility          as U
 import           Language.Haskell.LSP.VFS
 import           System.Exit

--- a/haskell-lsp-types/haskell-lsp-types.cabal
+++ b/haskell-lsp-types/haskell-lsp-types.cabal
@@ -20,6 +20,7 @@ library
   exposed-modules:     Language.Haskell.LSP.Types
                      , Language.Haskell.LSP.Types.Capabilities
                      , Language.Haskell.LSP.Types.Constants
+                     , Language.Haskell.LSP.Types.Lens
                      , Language.Haskell.LSP.Types.MessageFuncs
                      , Language.Haskell.LSP.Types.Utils
   other-modules:       Language.Haskell.LSP.Types.ClientCapabilities
@@ -31,7 +32,6 @@ library
                      , Language.Haskell.LSP.Types.Diagnostic
                      , Language.Haskell.LSP.Types.DocumentFilter
                      , Language.Haskell.LSP.Types.FoldingRange
-                     , Language.Haskell.LSP.Types.Lens
                      , Language.Haskell.LSP.Types.List
                      , Language.Haskell.LSP.Types.Location
                      , Language.Haskell.LSP.Types.MarkupContent

--- a/haskell-lsp-types/src/Language/Haskell/LSP/Types.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/Types.hs
@@ -1,6 +1,5 @@
 module Language.Haskell.LSP.Types
   ( module Language.Haskell.LSP.Types.DataTypesJSON
-  , module Language.Haskell.LSP.Types.Lens
   , module Language.Haskell.LSP.Types.CodeAction
   , module Language.Haskell.LSP.Types.Color
   , module Language.Haskell.LSP.Types.Command
@@ -21,7 +20,6 @@ module Language.Haskell.LSP.Types
 where
 
 import           Language.Haskell.LSP.Types.DataTypesJSON
-import           Language.Haskell.LSP.Types.Lens
 import           Language.Haskell.LSP.Types.CodeAction
 import           Language.Haskell.LSP.Types.Color
 import           Language.Haskell.LSP.Types.Command

--- a/haskell-lsp.cabal
+++ b/haskell-lsp.cabal
@@ -23,6 +23,7 @@ cabal-version:       1.22
 library
   reexported-modules:  Language.Haskell.LSP.Types
                      , Language.Haskell.LSP.Types.Capabilities
+                     , Language.Haskell.LSP.Types.Lens
   exposed-modules:     Language.Haskell.LSP.Capture
                      , Language.Haskell.LSP.Constant
                      , Language.Haskell.LSP.Core

--- a/src/Language/Haskell/LSP/Core.hs
+++ b/src/Language/Haskell/LSP/Core.hs
@@ -44,6 +44,7 @@ import           Language.Haskell.LSP.Constant
 import           Language.Haskell.LSP.Messages
 import qualified Language.Haskell.LSP.Types.Capabilities    as C
 import qualified Language.Haskell.LSP.Types                 as J
+import qualified Language.Haskell.LSP.Types.Lens            as J
 import           Language.Haskell.LSP.Utility
 import           Language.Haskell.LSP.VFS
 import           Language.Haskell.LSP.Diagnostics

--- a/src/Language/Haskell/LSP/VFS.hs
+++ b/src/Language/Haskell/LSP/VFS.hs
@@ -38,6 +38,7 @@ import qualified Data.HashMap.Strict as HashMap
 import qualified Data.Map as Map
 import           Data.Maybe
 import qualified Language.Haskell.LSP.Types           as J
+import qualified Language.Haskell.LSP.Types.Lens      as J
 import           Language.Haskell.LSP.Utility
 import qualified Yi.Rope as Yi
 

--- a/test/ServerCapabilitiesSpec.hs
+++ b/test/ServerCapabilitiesSpec.hs
@@ -5,6 +5,7 @@ import Control.Lens.Operators
 import Data.Aeson
 import Data.Monoid ((<>))
 import Language.Haskell.LSP.Types
+import Language.Haskell.LSP.Types.Lens
 import Test.Hspec
 
 spec :: Spec


### PR DESCRIPTION
Since we've added lenses for client capabilities, there's been a lot more name collisions when importing `Language.Haskell.LSP.Types`. Not every module uses lenses so this means that it can be imported only when needed, and possibly qualified separately. 