### PR TITLE
Added stack-8.4.4.yaml with lts-12.26

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,6 +89,11 @@ jobs:
       - STACK_FILE: "stack-8.4.3.yaml"
     <<: *defaults
 
+  ghc-8.4.4:
+    environment:
+      - STACK_FILE: "stack-8.4.4.yaml"
+    <<: *defaults
+
   ghc-8.6.1:
     environment:
       - STACK_FILE: "stack-8.6.1.yaml"
@@ -107,6 +112,6 @@ workflows:
       - ghc-8.2.2
       - ghc-8.4.2
       - ghc-8.4.3
+      - ghc-8.4.4
       - ghc-8.6.1
       - ghc-8.6.3
-

--- a/stack-8.4.4.yaml
+++ b/stack-8.4.4.yaml
@@ -1,0 +1,12 @@
+resolver: lts-12.26 # GHC 8.4.4
+
+packages:
+- '.'
+- ./haskell-lsp-types
+
+extra-deps:
+
+flags: {}
+extra-package-dbs: []
+nix:
+  packages: [icu]


### PR DESCRIPTION
This is rather trivial commit that enables building haskell-lsp with ghc-8.4.4. I have checked that it  compiles and passes tests.