### PR TITLE
Fix name of Folding Range request method name

### DIFF
--- a/haskell-lsp-types/src/Language/Haskell/LSP/Types/Message.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/Types/Message.hs
@@ -112,7 +112,7 @@ data ClientMethod =
  | TextDocumentRangeFormatting
  | TextDocumentOnTypeFormatting
  | TextDocumentRename
- | TextDocumentFoldingRanges
+ | TextDocumentFoldingRange
  -- Messages of the form $/message
  -- Implementation Dependent, can be ignored
  | Misc Text
@@ -159,7 +159,7 @@ instance A.FromJSON ClientMethod where
   parseJSON (A.String "textDocument/rangeFormatting")     = return TextDocumentRangeFormatting
   parseJSON (A.String "textDocument/onTypeFormatting")    = return TextDocumentOnTypeFormatting
   parseJSON (A.String "textDocument/rename")              = return TextDocumentRename
-  parseJSON (A.String "textDocument/foldingRanges")       = return TextDocumentFoldingRanges
+  parseJSON (A.String "textDocument/foldingRange")        = return TextDocumentFoldingRange
   parseJSON (A.String x)                                  = if T.isPrefixOf "$/" x
                                                                then return $ Misc (T.drop 2 x)
                                                             else mempty
@@ -204,7 +204,7 @@ instance A.ToJSON ClientMethod where
   toJSON TextDocumentRangeFormatting     = A.String "textDocument/rangeFormatting"
   toJSON TextDocumentOnTypeFormatting    = A.String "textDocument/onTypeFormatting"
   toJSON TextDocumentRename              = A.String "textDocument/rename"
-  toJSON TextDocumentFoldingRanges       = A.String "textDocument/foldingRanges"
+  toJSON TextDocumentFoldingRange        = A.String "textDocument/foldingRange"
   toJSON TextDocumentDocumentLink        = A.String "textDocument/documentLink"
   toJSON DocumentLinkResolve             = A.String "documentLink/resolve"
   toJSON (Misc xs)                       = A.String $ "$/" <> xs

--- a/src/Language/Haskell/LSP/Core.hs
+++ b/src/Language/Haskell/LSP/Core.hs
@@ -306,7 +306,7 @@ handlerMap _ h J.TextDocumentColorPresentation   = hh nop ReqColorPresentation $
 handlerMap _ h J.TextDocumentDocumentLink        = hh nop ReqDocumentLink $ documentLinkHandler h
 handlerMap _ h J.DocumentLinkResolve             = hh nop ReqDocumentLinkResolve $ documentLinkResolveHandler h
 handlerMap _ h J.TextDocumentRename              = hh nop ReqRename $ renameHandler h
-handlerMap _ h J.TextDocumentFoldingRanges       = hh nop ReqFoldingRange $ foldingRangeHandler h
+handlerMap _ h J.TextDocumentFoldingRange        = hh nop ReqFoldingRange $ foldingRangeHandler h
 handlerMap _ _ (J.Misc x)   = helper f
   where f ::  TVar (LanguageContextData c) -> J.Value -> IO ()
         f tvarDat n = do


### PR DESCRIPTION
The method name should be `textDocument/foldingRange`

https://microsoft.github.io/language-server-protocol/specification#textDocument_foldingRange