### PR TITLE
Added A NFData instance for Diagnostics

### DIFF
--- a/haskell-lsp-types/haskell-lsp-types.cabal
+++ b/haskell-lsp-types/haskell-lsp-types.cabal
@@ -49,6 +49,7 @@ library
                      , aeson >=1.0.0.0
                      , bytestring
                      , data-default
+                     , deepseq
                      , filepath
                      , hashable
                      , lens >= 4.15.2

--- a/haskell-lsp-types/src/Language/Haskell/LSP/Types/Diagnostic.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/Types/Diagnostic.hs
@@ -1,11 +1,14 @@
 {-# LANGUAGE DuplicateRecordFields      #-}
 {-# LANGUAGE TemplateHaskell            #-}
+{-# LANGUAGE DeriveGeneric              #-}
 
 module Language.Haskell.LSP.Types.Diagnostic where
 
+import           Control.DeepSeq
 import qualified Data.Aeson                                 as A
 import           Data.Aeson.TH
 import           Data.Text
+import           GHC.Generics
 import           Language.Haskell.LSP.Types.Constants
 import           Language.Haskell.LSP.Types.List
 import           Language.Haskell.LSP.Types.Location
@@ -38,7 +41,9 @@ data DiagnosticSeverity
   | DsWarning -- ^ Warning = 2,
   | DsInfo    -- ^ Info = 3,
   | DsHint    -- ^ Hint = 4
-  deriving (Eq,Ord,Show,Read)
+  deriving (Eq,Ord,Show,Read, Generic)
+
+instance NFData DiagnosticSeverity
 
 instance A.ToJSON DiagnosticSeverity where
   toJSON DsError   = A.Number 1
@@ -76,7 +81,9 @@ data DiagnosticRelatedInformation =
   DiagnosticRelatedInformation
     { _location :: Location
     , _message  :: Text
-    } deriving (Show, Read, Eq, Ord)
+    } deriving (Show, Read, Eq, Ord, Generic)
+
+instance NFData DiagnosticRelatedInformation
 
 deriveJSON lspOptions ''DiagnosticRelatedInformation
 
@@ -134,6 +141,8 @@ data Diagnostic =
     , _source             :: Maybe DiagnosticSource
     , _message            :: Text
     , _relatedInformation :: Maybe (List DiagnosticRelatedInformation)
-    } deriving (Show, Read, Eq, Ord)
+    } deriving (Show, Read, Eq, Ord, Generic)
+
+instance NFData Diagnostic
 
 deriveJSON lspOptions ''Diagnostic

--- a/haskell-lsp-types/src/Language/Haskell/LSP/Types/List.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/Types/List.hs
@@ -3,15 +3,20 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE DeriveTraversable          #-}
+{-# LANGUAGE DeriveGeneric              #-}
 module Language.Haskell.LSP.Types.List where
 
+import           Control.DeepSeq
 import qualified Data.Aeson                                 as A
 import           Data.Aeson.Types
+import           GHC.Generics
 
 -- | This data type is used to host a FromJSON instance for the encoding used by
 -- elisp, where an empty list shows up as "null"
 newtype List a = List [a]
-                deriving (Show,Read,Eq,Ord,Monoid,Functor,Foldable,Traversable)
+                deriving (Show,Read,Eq,Ord,Monoid,Functor,Foldable,Traversable,Generic)
+
+instance NFData a => NFData (List a)
 
 instance (A.ToJSON a) => A.ToJSON (List a) where
   toJSON (List ls) = toJSON ls

--- a/haskell-lsp-types/src/Language/Haskell/LSP/Types/Location.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/Types/Location.hs
@@ -1,7 +1,10 @@
 {-# LANGUAGE TemplateHaskell            #-}
+{-# LANGUAGE DeriveGeneric              #-}
 module Language.Haskell.LSP.Types.Location where
 
+import           Control.DeepSeq
 import           Data.Aeson.TH
+import           GHC.Generics
 import           Language.Haskell.LSP.Types.Constants
 import           Language.Haskell.LSP.Types.Uri
 
@@ -39,8 +42,9 @@ data Position =
   Position
     { _line      :: Int
     , _character :: Int
-    } deriving (Show, Read, Eq, Ord)
+    } deriving (Show, Read, Eq, Ord, Generic)
 
+instance NFData Position
 deriveJSON lspOptions ''Position
 
 -- ---------------------------------------------------------------------
@@ -68,8 +72,9 @@ data Range =
   Range
     { _start :: Position
     , _end   :: Position
-    } deriving (Show, Read, Eq, Ord)
+    } deriving (Show, Read, Eq, Ord, Generic)
 
+instance NFData Range
 deriveJSON lspOptions ''Range
 
 -- ---------------------------------------------------------------------
@@ -88,6 +93,7 @@ data Location =
   Location
     { _uri   :: Uri
     , _range :: Range
-    } deriving (Show, Read, Eq, Ord)
+    } deriving (Show, Read, Eq, Ord, Generic)
 
+instance NFData Location
 deriveJSON lspOptions ''Location

--- a/haskell-lsp-types/src/Language/Haskell/LSP/Types/Uri.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/Types/Uri.hs
@@ -1,17 +1,22 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE DeriveGeneric #-}
 module Language.Haskell.LSP.Types.Uri where
 
+import           Control.DeepSeq
 import qualified Data.Aeson                                 as A
 import           Data.Hashable
 import           Data.Text                                  (Text)
 import qualified Data.Text                                  as T
+import           GHC.Generics
 import           Network.URI
 import qualified System.FilePath.Posix                      as FPP
 import qualified System.FilePath.Windows                    as FPW
 import qualified System.Info
 
 newtype Uri = Uri { getUri :: Text }
-  deriving (Eq,Ord,Read,Show,A.FromJSON,A.ToJSON,Hashable,A.ToJSONKey,A.FromJSONKey)
+  deriving (Eq,Ord,Read,Show,Generic,A.FromJSON,A.ToJSON,Hashable,A.ToJSONKey,A.FromJSONKey)
+
+instance NFData Uri
 
 fileScheme :: String
 fileScheme = "file:"


### PR DESCRIPTION
Adds the NFData instance, which is useful for things like interoperating with Shake, which requires NFData instances. Patch originally by @DavidM-D.