### PR TITLE
Fix exception on empty filepaths

### DIFF
--- a/haskell-lsp-types/src/Language/Haskell/LSP/Types/Uri.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/Types/Uri.hs
@@ -58,7 +58,7 @@ platformAwareFilePathToUri systemOS fp = Uri . T.pack . show $ URI
 
 platformAdjustToUriPath :: SystemOS -> FilePath -> String
 platformAdjustToUriPath systemOS srcPath =
-  if systemOS /= windowsOS then srcPath
+  if systemOS /= windowsOS || null srcPath then srcPath
     else let
       drive:rest = FPW.splitDirectories srcPath
       leaveCharUnescaped = (/= ':')


### PR DESCRIPTION
This is the same way we handle empty files in `platformAdjustFromUriPath`, but I'm happy to handle this in another way