### PR TITLE
Fix relative posix uris

### DIFF
--- a/test/URIFilePathSpec.hs
+++ b/test/URIFilePathSpec.hs
@@ -23,6 +23,9 @@ testPosixUri = Uri $ pack "file:///home/myself/example.hs"
 testPosixFilePath :: FilePath
 testPosixFilePath = "/home/myself/example.hs"
 
+relativePosixFilePath :: FilePath
+relativePosixFilePath = "myself/example.hs"
+
 testWindowsUri :: Uri
 testWindowsUri = Uri $ pack "file:///c%3A/Users/myself/example.hs"
 
@@ -73,3 +76,9 @@ filePathUriSpec = do
       ,"")
     Just "/Functional.hs" `shouldBe` platformAwareUriToFilePath "posix" theFilePath
 
+
+  it "converts a relative POSIX file path to a URI and back" $ do
+    let uri = platformAwareFilePathToUri "posix" relativePosixFilePath
+    uri `shouldBe` Uri "file://myself/example.hs"
+    let back = platformAwareUriToFilePath "posix" uri
+    back `shouldBe` Just relativePosixFilePath

--- a/test/URIFilePathSpec.hs
+++ b/test/URIFilePathSpec.hs
@@ -74,7 +74,7 @@ filePathUriSpec = do
       ,"/Functional.hs"
       ,""
       ,"")
-    Just "/Functional.hs" `shouldBe` platformAwareUriToFilePath "posix" theFilePath
+    Just "./Functional.hs" `shouldBe` platformAwareUriToFilePath "posix" theFilePath
 
 
   it "converts a relative POSIX file path to a URI and back" $ do


### PR DESCRIPTION
Make going to and from a URI a bit more symmetrical, discussed here https://github.com/alanz/haskell-lsp/issues/167. This is a bit hacky and perhaps should be further up-streamed to the Haskell Uri library