### PR TITLE
Add support for custom request and notification methods

### DIFF
--- a/haskell-lsp-types/src/Language/Haskell/LSP/Types/DataTypesJSON.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/Types/DataTypesJSON.hs
@@ -841,6 +841,14 @@ Notification:
 
 type TelemetryNotification = NotificationMessage ServerMethod A.Value
 
+type CustomClientNotification = NotificationMessage ClientMethod A.Value
+type CustomServerNotification = NotificationMessage ServerMethod A.Value
+
+type CustomClientRequest = RequestMessage ClientMethod A.Value A.Value
+type CustomServerRequest = RequestMessage ServerMethod A.Value A.Value
+
+type CustomResponse = ResponseMessage A.Value
+
 -- ---------------------------------------------------------------------
 {-
 New in 3.0

--- a/src/Language/Haskell/LSP/Messages.hs
+++ b/src/Language/Haskell/LSP/Messages.hs
@@ -61,8 +61,12 @@ data FromClientMessage = ReqInitialize               InitializeRequest
                        | NotDidChangeWatchedFiles        DidChangeWatchedFilesNotification
                        | NotDidChangeWorkspaceFolders    DidChangeWorkspaceFoldersNotification
                        | NotProgressCancel               ProgressCancelNotification
-                       -- Unknown (The client sends something we don't understand)
-                       | UnknownFromClientMessage        Value
+
+                       -- It is common for language servers to add custom message types so these
+                       -- three constructors can be used to handle custom request, response or notification
+                       -- types.
+                       | ReqCustomClient                 CustomClientRequest
+                       | NotCustomClient                 CustomClientNotification
   deriving (Eq,Read,Show,Generic,ToJSON,FromJSON)
 
 -- | A wrapper around a message that originates from the server
@@ -110,4 +114,11 @@ data FromServerMessage = ReqRegisterCapability       RegisterCapabilityRequest
                        | NotTelemetry                TelemetryNotification
                        -- A cancel request notification is duplex!
                        | NotCancelRequestFromServer  CancelNotificationServer
+
+                       -- It is common for language servers to add custom message types so these
+                       -- three constructors can be used to handle custom request, response or notification
+                       -- types.
+                       | ReqCustomServer             CustomServerRequest
+                       | RspCustomServer             CustomResponse
+                       | NotCustomServer             CustomServerNotification
   deriving (Eq,Read,Show,Generic,ToJSON,FromJSON)


### PR DESCRIPTION
It is relatively common to extend LSP with custom method types that
are specific to a given language so it makes sense for haskell-lsp to
support this.

To accomplish this, this PR introduces the following changes:

1. Remove the `Misc` constructor in favor of a more explicit
   `CustomClientMethod` constructor that does not enforce that methods
   start with $/. While the spec mentions that custom methods should
   start with $/, I’ve seen custom methods that do not start with $/
   and given that haskell-lsp can only control the server side but not
   the client side, e.g., VSCode extensions, I think it makes more
   sense to be relaxed here.

2. Add `ReqCustomClient` and `NotCustomClient` to `FromClientMessage`
   while removing `UnknownFromClientMessage` (any valid JSON-RPC
   message should now be decodable).

3. Add handlers for `ReqCustomClient` and `NotCustomClient`.

4. It adds `ReqCustomServer`, `RspCustomServer` and `NotCustomServer`
   to `FromServerMessage`.

Note that this PR does not add `RspCustomClient`. This is because
responses are always decoded to `BareResponseMessage` with no
restrictions so it would be redundant. Once `BareResponseMessage` is
removed in favor of explicit response types, this constructor and a
corresponding handler should be added.