### PR TITLE
Fix decoding of ResponseMessage

### DIFF
--- a/haskell-lsp-types/src/Language/Haskell/LSP/Types/Message.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/Types/Message.hs
@@ -384,7 +384,16 @@ data ResponseMessage a =
     , _error   :: Maybe ResponseError
     } deriving (Read,Show,Eq)
 
-deriveJSON lspOptions ''ResponseMessage
+deriveToJSON lspOptions ''ResponseMessage
+
+instance FromJSON a => FromJSON (ResponseMessage a) where
+  parseJSON = withObject "Response" $ \o ->
+    ResponseMessage
+      <$> o .: "jsonrpc"
+      <*> o .: "id"
+      -- It is important to use .:! so that result = null gets decoded as Just Nothing
+      <*> o .:! "result"
+      <*> o .:! "error"
 
 type ErrorResponse = ResponseMessage ()
 

--- a/test/JsonSpec.hs
+++ b/test/JsonSpec.hs
@@ -31,16 +31,17 @@ jsonSpec :: Spec
 jsonSpec = do
   describe "General JSON instances round trip" $ do
   -- DataTypesJSON
-    prop "LanguageString"    (propertyJsonRoundtrip :: LanguageString -> Bool)
-    prop "MarkedString"      (propertyJsonRoundtrip :: MarkedString -> Bool)
-    prop "MarkupContent"     (propertyJsonRoundtrip :: MarkupContent -> Bool)
-    prop "HoverContents"     (propertyJsonRoundtrip :: HoverContents -> Bool)
+    prop "LanguageString"    (propertyJsonRoundtrip :: LanguageString -> Property)
+    prop "MarkedString"      (propertyJsonRoundtrip :: MarkedString -> Property)
+    prop "MarkupContent"     (propertyJsonRoundtrip :: MarkupContent -> Property)
+    prop "HoverContents"     (propertyJsonRoundtrip :: HoverContents -> Property)
+    prop "ResponseMessage"   (propertyJsonRoundtrip :: ResponseMessage (Maybe ()) -> Property)
 
 
 -- ---------------------------------------------------------------------
 
-propertyJsonRoundtrip :: (Eq a, ToJSON a, FromJSON a) => a -> Bool
-propertyJsonRoundtrip a = Success a == fromJSON (toJSON a)
+propertyJsonRoundtrip :: (Eq a, Show a, ToJSON a, FromJSON a) => a -> Property
+propertyJsonRoundtrip a = Success a === fromJSON (toJSON a)
 
 -- ---------------------------------------------------------------------
 
@@ -60,6 +61,35 @@ instance Arbitrary HoverContents where
   arbitrary = oneof [ HoverContentsMS <$> arbitrary
                     , HoverContents <$> arbitrary
                     ]
+
+instance Arbitrary a => Arbitrary (ResponseMessage a) where
+  arbitrary =
+    ResponseMessage
+      <$> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+
+instance Arbitrary LspIdRsp where
+  arbitrary = oneof [IdRspInt <$> arbitrary, IdRspString <$> arbitrary, pure IdRspNull]
+
+instance Arbitrary ResponseError where
+  arbitrary = ResponseError <$> arbitrary <*> arbitrary <*> pure Nothing
+
+instance Arbitrary ErrorCode where
+  arbitrary =
+    elements
+      [ ParseError
+      , InvalidRequest
+      , MethodNotFound
+      , InvalidParams
+      , InternalError
+      , ServerErrorStart
+      , ServerErrorEnd
+      , ServerNotInitialized
+      , UnknownErrorCode
+      , RequestCancelled
+      ]
 
 -- | make lists of maximum length 3 for test performance
 smallList :: Gen a -> Gen [a]


### PR DESCRIPTION
`result = Just Nothing` gets encoded to `result = null` in
JSON. However, upon decoding that gives us `result = Nothing` so we
cannot roundtrip. This is obviously undesirable and also breaks the
assumption that exactly one of `result` or `error` must be `Just`. As
far as I know, there is know way to get this behavior by setting Aeson
options, so I switched to a hand-written FromJSON instance for
`ResponseMessage`.