### PR TITLE
Use attoparsec to parse message headers incrementally

### DIFF
--- a/haskell-lsp.cabal
+++ b/haskell-lsp.cabal
@@ -38,6 +38,7 @@ library
   build-depends:       base >=4.9 && <4.13
                      , async
                      , aeson >=1.0.0.0
+                     , attoparsec
                      , bytestring
                      , containers
                      , directory
@@ -49,7 +50,6 @@ library
                      , lens >= 4.15.2
                      , mtl
                      , network-uri
-                     , parsec
                      , rope-utf16-splay >= 0.3.1.0
                      , sorted-list == 0.2.1.*
                      , stm
@@ -78,7 +78,6 @@ executable lsp-hello
                      , lens >= 4.15.2
                      , mtl
                      , network-uri
-                     , parsec
                      , rope-utf16-splay >= 0.2
                      , stm
                      , text

--- a/src/Language/Haskell/LSP/Core.hs
+++ b/src/Language/Haskell/LSP/Core.hs
@@ -497,8 +497,8 @@ defaultProgressData = ProgressData 0 Map.empty
 -- ---------------------------------------------------------------------
 
 handleMessage :: (Show c) => InitializeCallback c
-              -> TVar (LanguageContextData c) -> BSL.ByteString -> BSL.ByteString -> IO ()
-handleMessage dispatcherProc tvarDat contLenStr jsonStr = do
+              -> TVar (LanguageContextData c) -> BSL.ByteString -> IO ()
+handleMessage dispatcherProc tvarDat jsonStr = do
   {-
   Message Types we must handle are the following
 
@@ -510,7 +510,7 @@ handleMessage dispatcherProc tvarDat contLenStr jsonStr = do
 
   case J.eitherDecode jsonStr :: Either String J.Object of
     Left  err -> do
-      let msg =  T.pack $ unwords [ "haskell-lsp:incoming message parse error.", lbs2str contLenStr, lbs2str jsonStr, show err]
+      let msg =  T.pack $ unwords [ "haskell-lsp:incoming message parse error.", lbs2str jsonStr, show err]
               ++ L.intercalate "\n" ("" : "" : _ERR_MSG_URL)
               ++ "\n"
       sendErrorLog tvarDat msg
@@ -522,7 +522,7 @@ handleMessage dispatcherProc tvarDat contLenStr jsonStr = do
                                    J.Success m -> handle (J.Object o) m
                                    J.Error _ -> do
                                      let msg = T.pack $ unwords ["haskell-lsp:unknown message received:method='"
-                                                                 ++ T.unpack s ++ "',", lbs2str contLenStr, lbs2str jsonStr]
+                                                                 ++ T.unpack s ++ "',", lbs2str jsonStr]
                                      sendErrorLog tvarDat msg
         Just oops -> logs $ "haskell-lsp:got strange method param, ignoring:" ++ show oops
         Nothing -> do

--- a/test/WorkspaceFoldersSpec.hs
+++ b/test/WorkspaceFoldersSpec.hs
@@ -5,7 +5,6 @@ module WorkspaceFoldersSpec where
 import Control.Concurrent.MVar
 import Control.Concurrent.STM
 import Data.Aeson
-import qualified Data.ByteString.Lazy.Char8 as BSL
 import Data.Default
 import Language.Haskell.LSP.Core
 import Language.Haskell.LSP.Types
@@ -28,8 +27,7 @@ spec = describe "workspace folders" $
 
     let putMsg msg =
           let jsonStr = encode msg
-              clStr = BSL.pack $ "Content-Length: " ++ show (BSL.length jsonStr)
-            in handleMessage initCb tvarCtx clStr jsonStr
+            in handleMessage initCb tvarCtx jsonStr
 
     let starterWorkspaces = List [wf0]
         initParams = InitializeParams


### PR DESCRIPTION
Previously, we were repeatedly reading one character, appending it to
the end and trying to parse until parsec returned a result. This is
needlessly wasteful and while it’s probably not a bottleneck, I think
the incremental parsing with attoparsec is also easier to understand
so it’s a win both in readability and performance.