### PR TITLE
 Document textDocumentDidChange handler to mention VFS and suppress warnings

### DIFF
--- a/src/Language/Haskell/LSP/Core.hs
+++ b/src/Language/Haskell/LSP/Core.hs
@@ -234,6 +234,8 @@ data Handlers =
     , didChangeConfigurationParamsHandler      :: !(Maybe (Handler J.DidChangeConfigurationNotification))
     , didOpenTextDocumentNotificationHandler   :: !(Maybe (Handler J.DidOpenTextDocumentNotification))
     , didChangeTextDocumentNotificationHandler :: !(Maybe (Handler J.DidChangeTextDocumentNotification))
+    -- ^ Note: If you need to keep track of document changes,
+    -- "Language.Haskell.LSP.VFS" will take care of these messages for you!
     , didCloseTextDocumentNotificationHandler  :: !(Maybe (Handler J.DidCloseTextDocumentNotification))
     , didSaveTextDocumentNotificationHandler   :: !(Maybe (Handler J.DidSaveTextDocumentNotification))
     , didChangeWatchedFilesNotificationHandler :: !(Maybe (Handler J.DidChangeWatchedFilesNotification))

--- a/src/Language/Haskell/LSP/Core.hs
+++ b/src/Language/Haskell/LSP/Core.hs
@@ -263,11 +263,19 @@ data Handlers =
     }
 
 instance Default Handlers where
-  def = Handlers Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing
-                 Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing
-                 Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing
-                 Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing
-                 Nothing Nothing Nothing Nothing
+  -- These already implicitly do stuff to the VFS, so silence warnings about no handler
+  def = nothings { didChangeTextDocumentNotificationHandler = Just ignore
+                 , didOpenTextDocumentNotificationHandler   = Just ignore
+                 , didCloseTextDocumentNotificationHandler  = Just ignore
+                 }
+    where ignore = const (pure ())
+          nothings = Handlers Nothing Nothing Nothing Nothing Nothing Nothing
+                              Nothing Nothing Nothing Nothing Nothing Nothing
+                              Nothing Nothing Nothing Nothing Nothing Nothing
+                              Nothing Nothing Nothing Nothing Nothing Nothing
+                              Nothing Nothing Nothing Nothing Nothing Nothing
+                              Nothing Nothing Nothing Nothing Nothing Nothing
+                              Nothing Nothing Nothing Nothing
 
 -- ---------------------------------------------------------------------
 nop :: a -> b -> IO a

--- a/src/Language/Haskell/LSP/VFS.hs
+++ b/src/Language/Haskell/LSP/VFS.hs
@@ -5,10 +5,12 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE ViewPatterns #-}
 
-{-
-
-Manage the J.TextDocumentDidChange messages to keep a local copy of the files
-in the client workspace, so that tools at the server can operate on them.
+{-|
+Handles the "Language.Haskell.LSP.Types.TextDocumentDidChange" \/
+"Language.Haskell.LSP.Types.TextDocumentDidOpen" \/
+"Language.Haskell.LSP.Types.TextDocumentDidClose" messages to keep an in-memory
+`filesystem` of the current client workspace.  The server can access and edit
+files in the client workspace by operating on the "VFS" in "LspFuncs".
 -}
 module Language.Haskell.LSP.VFS
   (


### PR DESCRIPTION
@EggBaconAndSpam mentioned during his GSOC work on dhall-lsp-server that it wasn't obvious that the VFS exists! We should probably document this better. Later on I will try and update the example to use VFS