### PR TITLE
Add stack.yaml for 8.6.5 and mask lsp-hello behind flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ It can also be used with emacs, see https://github.com/emacs-lsp/lsp-haskell
 
 ## Using the example server
 
-    stack install
+    stack install :lsp-hello --flag haskell-lsp:demo
 
 will generate a `lsp-hello` executable.
 

--- a/haskell-lsp.cabal
+++ b/haskell-lsp.cabal
@@ -88,6 +88,13 @@ executable lsp-hello
                      , vector
                      -- the package library. Comment this out if you want repl changes to propagate
                      , haskell-lsp
+  if !flag(demo)
+    buildable:         False
+
+flag demo {
+  description: Build the lsp-hello demo executable
+  default:     False
+}
 
 test-suite haskell-lsp-test
   type:                exitcode-stdio-1.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,13 @@
+resolver: lts-13.25 # GHC 8.6.5
+
+packages:
+- '.'
+- ./haskell-lsp-types
+
+extra-deps:
+- rope-utf16-splay-0.3.1.0
+
+flags: {}
+extra-package-dbs: []
+nix:
+  packages: [icu]


### PR DESCRIPTION
This prevents stack from building the executable when the library is included as a dependency, so should hopefully save some build time. cabal v2-build doesn't seem to build the executable by default.
Here are my experiments with stack:

```
$ cat foo.cabal 
cabal-version:       2.4
-- Initial package description 'foo.cabal' generated by 'cabal init'.  For
-- further documentation, see http://haskell.org/cabal/users-guide/

name:                foo
version:             0.1.0.0
-- synopsis:
-- description:
-- bug-reports:
license:             BSD-3-Clause
license-file:        LICENSE
author:              Luke Lau
maintainer:          luke_lau@icloud.com
-- copyright:
-- category:
extra-source-files:  CHANGELOG.md

library
  -- exposed-modules:
  -- other-modules:
  -- other-extensions:
  build-depends:       base ^>=4.12.0.0
                     , bar
  -- hs-source-dirs:
  default-language:    Haskell2010
$ cat bar/bar.cabal 
cabal-version:       2.4
-- Initial package description 'bar.cabal' generated by 'cabal init'.  For
-- further documentation, see http://haskell.org/cabal/users-guide/

name:                bar
version:             0.1.0.0
-- synopsis:
-- description:
-- bug-reports:
license:             BSD-3-Clause
license-file:        LICENSE
author:              Luke Lau
maintainer:          luke_lau@icloud.com
-- copyright:
-- category:
extra-source-files:  CHANGELOG.md

library
  -- exposed-modules:
  -- other-modules:
  -- other-extensions:
  build-depends:       base ^>=4.12.0.0
  -- hs-source-dirs:
  default-language:    Haskell2010

executable bar
  main-is:             Main.hs
  -- other-modules:
  -- other-extensions:
  build-depends:       base ^>=4.12.0.0
  -- hs-source-dirs:
  default-language:    Haskell2010
  buildable: False
$ stack
Building all executables for `bar' once. After a successful build of all of them, only specified executables will be rebuilt.
bar-0.1.0.0: configure (lib + exe)
bar-0.1.0.0: build (lib + exe)
bar-0.1.0.0: copy/register
foo-0.1.0.0: configure (lib)
foo-0.1.0.0: build (lib) 
foo-0.1.0.0: copy/register
Completed 2 action(s).   
Log files have been written to: /Users/luke/Desktop/foo/.stack-work/logs/
$ rm -r .stack-work/
$ vim bar/bar.cabal # here I set buildable: False on the bar executable
$ stack build
bar-0.1.0.0: configure (lib)
bar-0.1.0.0: build (lib)
bar-0.1.0.0: copy/register
foo-0.1.0.0: configure (lib)
foo-0.1.0.0: build (lib) 
foo-0.1.0.0: copy/register
Completed 2 action(s).   
Log files have been written to: /Users/luke/Desktop/foo/.stack-work/logs/
```