### PR TITLE
Normalize URIs to avoid issues with percent encoding

### DIFF
--- a/haskell-lsp-types/src/Language/Haskell/LSP/Types/Uri.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/Types/Uri.hs
@@ -19,6 +19,19 @@ newtype Uri = Uri { getUri :: Text }
 
 instance NFData Uri
 
+-- | When URIs are supposed to be used as keys, it is important to normalize
+-- the percent encoding in the URI since URIs that only differ
+-- when it comes to the percent-encoding should be treated as equivalent.
+newtype NormalizedUri = NormalizedUri Text
+  deriving (Eq,Ord,Read,Show,Generic,Hashable)
+
+toNormalizedUri :: Uri -> NormalizedUri
+toNormalizedUri (Uri t) =
+    NormalizedUri $ T.pack $ escapeURIString isUnescapedInURI $ unEscapeString $ T.unpack t
+
+fromNormalizedUri :: NormalizedUri -> Uri
+fromNormalizedUri (NormalizedUri t) = Uri t
+
 fileScheme :: String
 fileScheme = "file:"
 

--- a/src/Language/Haskell/LSP/Diagnostics.hs
+++ b/src/Language/Haskell/LSP/Diagnostics.hs
@@ -39,7 +39,7 @@ all prior entries for the Uri.
 
 -}
 
-type DiagnosticStore = Map.Map J.Uri StoreItem
+type DiagnosticStore = Map.Map J.NormalizedUri StoreItem
 
 data StoreItem
   = StoreItem J.TextDocumentVersion DiagnosticsBySource
@@ -63,7 +63,7 @@ flushBySource store (Just source) = Map.map remove store
 -- ---------------------------------------------------------------------
 
 updateDiagnostics :: DiagnosticStore
-                  -> J.Uri -> J.TextDocumentVersion -> DiagnosticsBySource
+                  -> J.NormalizedUri -> J.TextDocumentVersion -> DiagnosticsBySource
                   -> DiagnosticStore
 updateDiagnostics store uri mv newDiagsBySource = r
   where
@@ -86,11 +86,11 @@ updateDiagnostics store uri mv newDiagsBySource = r
 
 -- ---------------------------------------------------------------------
 
-getDiagnosticParamsFor :: Int -> DiagnosticStore -> J.Uri -> Maybe J.PublishDiagnosticsParams
+getDiagnosticParamsFor :: Int -> DiagnosticStore -> J.NormalizedUri -> Maybe J.PublishDiagnosticsParams
 getDiagnosticParamsFor maxDiagnostics ds uri =
   case Map.lookup uri ds of
     Nothing -> Nothing
     Just (StoreItem _ diags) ->
-      Just $ J.PublishDiagnosticsParams uri (J.List (take maxDiagnostics $ SL.fromSortedList $ mconcat $ Map.elems diags))
+      Just $ J.PublishDiagnosticsParams (J.fromNormalizedUri uri) (J.List (take maxDiagnostics $ SL.fromSortedList $ mconcat $ Map.elems diags))
 
 -- ---------------------------------------------------------------------

--- a/test/DiagnosticsSpec.hs
+++ b/test/DiagnosticsSpec.hs
@@ -54,9 +54,10 @@ diagnosticsSpec = do
           [ mkDiagnostic (Just "hlint") "a"
           , mkDiagnostic (Just "hlint") "b"
           ]
-      (updateDiagnostics Map.empty (J.Uri "uri") Nothing (partitionBySource diags)) `shouldBe`
+        uri = J.toNormalizedUri $ J.Uri "uri"
+      (updateDiagnostics Map.empty uri Nothing (partitionBySource diags)) `shouldBe`
         Map.fromList
-          [ ((J.Uri "uri"),StoreItem Nothing $ Map.fromList [(Just "hlint", SL.toSortedList diags) ] )
+          [ (uri,StoreItem Nothing $ Map.fromList [(Just "hlint", SL.toSortedList diags) ] )
           ]
 
     -- ---------------------------------
@@ -67,9 +68,10 @@ diagnosticsSpec = do
           [ mkDiagnostic (Just "hlint") "a"
           , mkDiagnostic (Just "ghcmod") "b"
           ]
-      (updateDiagnostics Map.empty (J.Uri "uri") Nothing (partitionBySource diags)) `shouldBe`
+        uri = J.toNormalizedUri $ J.Uri "uri"
+      (updateDiagnostics Map.empty uri Nothing (partitionBySource diags)) `shouldBe`
         Map.fromList
-          [ ((J.Uri "uri"),StoreItem Nothing $ Map.fromList
+          [ (uri,StoreItem Nothing $ Map.fromList
                 [(Just "hlint",  SL.singleton (mkDiagnostic (Just "hlint")  "a"))
                 ,(Just "ghcmod", SL.singleton (mkDiagnostic (Just "ghcmod") "b"))
                 ])
@@ -83,9 +85,10 @@ diagnosticsSpec = do
           [ mkDiagnostic (Just "hlint") "a"
           , mkDiagnostic (Just "ghcmod") "b"
           ]
-      (updateDiagnostics Map.empty (J.Uri "uri") (Just 1) (partitionBySource diags)) `shouldBe`
+        uri = J.toNormalizedUri $ J.Uri "uri"
+      (updateDiagnostics Map.empty uri (Just 1) (partitionBySource diags)) `shouldBe`
         Map.fromList
-          [ ((J.Uri "uri"),StoreItem (Just 1) $ Map.fromList
+          [ (uri,StoreItem (Just 1) $ Map.fromList
                 [(Just "hlint",  SL.singleton (mkDiagnostic (Just "hlint")  "a"))
                 ,(Just "ghcmod", SL.singleton (mkDiagnostic (Just "ghcmod") "b"))
                 ])
@@ -103,10 +106,11 @@ diagnosticsSpec = do
         diags2 =
           [ mkDiagnostic (Just "hlint") "a2"
           ]
-      let origStore = updateDiagnostics Map.empty (J.Uri "uri") Nothing (partitionBySource diags1)
-      (updateDiagnostics origStore (J.Uri "uri") Nothing (partitionBySource diags2)) `shouldBe`
+        uri = J.toNormalizedUri $ J.Uri "uri"
+      let origStore = updateDiagnostics Map.empty uri Nothing (partitionBySource diags1)
+      (updateDiagnostics origStore uri Nothing (partitionBySource diags2)) `shouldBe`
         Map.fromList
-          [ ((J.Uri "uri"),StoreItem Nothing $ Map.fromList [(Just "hlint", SL.toSortedList diags2) ] )
+          [ (uri,StoreItem Nothing $ Map.fromList [(Just "hlint", SL.toSortedList diags2) ] )
           ]
 
     -- ---------------------------------
@@ -120,10 +124,11 @@ diagnosticsSpec = do
         diags2 =
           [ mkDiagnostic (Just "hlint") "a2"
           ]
-      let origStore = updateDiagnostics Map.empty (J.Uri "uri") Nothing (partitionBySource diags1)
-      (updateDiagnostics origStore (J.Uri "uri") Nothing (partitionBySource diags2)) `shouldBe`
+        uri = J.toNormalizedUri $ J.Uri "uri"
+      let origStore = updateDiagnostics Map.empty uri Nothing (partitionBySource diags1)
+      (updateDiagnostics origStore uri Nothing (partitionBySource diags2)) `shouldBe`
         Map.fromList
-          [ ((J.Uri "uri"),StoreItem Nothing $ Map.fromList
+          [ (uri,StoreItem Nothing $ Map.fromList
                 [(Just "hlint",  SL.singleton (mkDiagnostic (Just "hlint")  "a2"))
                 ,(Just "ghcmod", SL.singleton (mkDiagnostic (Just "ghcmod") "b1"))
               ] )
@@ -137,10 +142,11 @@ diagnosticsSpec = do
           [ mkDiagnostic (Just "hlint") "a1"
           , mkDiagnostic (Just "ghcmod") "b1"
           ]
-      let origStore = updateDiagnostics Map.empty (J.Uri "uri") Nothing (partitionBySource diags1)
-      (updateDiagnostics origStore (J.Uri "uri") Nothing (Map.fromList [(Just "ghcmod",SL.toSortedList [])])) `shouldBe`
+        uri = J.toNormalizedUri $ J.Uri "uri"
+      let origStore = updateDiagnostics Map.empty uri Nothing (partitionBySource diags1)
+      (updateDiagnostics origStore uri Nothing (Map.fromList [(Just "ghcmod",SL.toSortedList [])])) `shouldBe`
         Map.fromList
-          [ ((J.Uri "uri"),StoreItem Nothing $ Map.fromList
+          [ (uri,StoreItem Nothing $ Map.fromList
                 [(Just "ghcmod", SL.toSortedList [])
                 ,(Just "hlint",  SL.singleton (mkDiagnostic (Just "hlint")  "a1"))
                 ] )
@@ -159,10 +165,11 @@ diagnosticsSpec = do
         diags2 =
           [ mkDiagnostic (Just "hlint") "a2"
           ]
-      let origStore = updateDiagnostics Map.empty (J.Uri "uri") (Just 1) (partitionBySource diags1)
-      (updateDiagnostics origStore (J.Uri "uri") (Just 2) (partitionBySource diags2)) `shouldBe`
+        uri = J.toNormalizedUri $ J.Uri "uri"
+      let origStore = updateDiagnostics Map.empty uri (Just 1) (partitionBySource diags1)
+      (updateDiagnostics origStore uri (Just 2) (partitionBySource diags2)) `shouldBe`
         Map.fromList
-          [ ((J.Uri "uri"),StoreItem (Just 2) $ Map.fromList [(Just "hlint", SL.toSortedList diags2) ] )
+          [ (uri,StoreItem (Just 2) $ Map.fromList [(Just "hlint", SL.toSortedList diags2) ] )
           ]
 
     -- ---------------------------------
@@ -176,10 +183,11 @@ diagnosticsSpec = do
         diags2 =
           [ mkDiagnostic (Just "hlint") "a2"
           ]
-      let origStore = updateDiagnostics Map.empty (J.Uri "uri") (Just 1) (partitionBySource diags1)
-      (updateDiagnostics origStore (J.Uri "uri") (Just 2) (partitionBySource diags2)) `shouldBe`
+        uri = J.toNormalizedUri $ J.Uri "uri"
+      let origStore = updateDiagnostics Map.empty uri (Just 1) (partitionBySource diags1)
+      (updateDiagnostics origStore uri (Just 2) (partitionBySource diags2)) `shouldBe`
         Map.fromList
-          [ ((J.Uri "uri"),StoreItem (Just 2) $ Map.fromList
+          [ (uri,StoreItem (Just 2) $ Map.fromList
                 [(Just "hlint", SL.singleton (mkDiagnostic (Just "hlint")  "a2"))
               ] )
           ]
@@ -194,9 +202,10 @@ diagnosticsSpec = do
           [ mkDiagnostic (Just "hlint") "a"
           , mkDiagnostic (Just "ghcmod") "b"
           ]
-      let ds = updateDiagnostics Map.empty (J.Uri "uri") (Just 1) (partitionBySource diags)
-      (getDiagnosticParamsFor 10 ds (J.Uri "uri")) `shouldBe`
-        Just (J.PublishDiagnosticsParams (J.Uri "uri") (J.List $ reverse diags))
+        uri = J.toNormalizedUri $ J.Uri "uri"
+      let ds = updateDiagnostics Map.empty uri (Just 1) (partitionBySource diags)
+      (getDiagnosticParamsFor 10 ds uri) `shouldBe`
+        Just (J.PublishDiagnosticsParams (J.fromNormalizedUri uri) (J.List $ reverse diags))
 
     -- ---------------------------------
 
@@ -210,16 +219,17 @@ diagnosticsSpec = do
           , mkDiagnostic  (Just "hlint") "c"
           , mkDiagnostic  (Just "ghcmod") "d"
           ]
-      let ds = updateDiagnostics Map.empty (J.Uri "uri") (Just 1) (partitionBySource diags)
-      (getDiagnosticParamsFor 2 ds (J.Uri "uri")) `shouldBe`
-        Just (J.PublishDiagnosticsParams (J.Uri "uri")
+        uri = J.toNormalizedUri $ J.Uri "uri"
+      let ds = updateDiagnostics Map.empty uri (Just 1) (partitionBySource diags)
+      (getDiagnosticParamsFor 2 ds uri) `shouldBe`
+        Just (J.PublishDiagnosticsParams (J.fromNormalizedUri uri)
               (J.List [
                     mkDiagnostic  (Just "ghcmod") "d"
                   , mkDiagnostic  (Just "hlint") "c"
                   ]))
 
-      (getDiagnosticParamsFor 1 ds (J.Uri "uri")) `shouldBe`
-        Just (J.PublishDiagnosticsParams (J.Uri "uri")
+      (getDiagnosticParamsFor 1 ds uri) `shouldBe`
+        Just (J.PublishDiagnosticsParams (J.fromNormalizedUri uri)
               (J.List [
                     mkDiagnostic  (Just "ghcmod") "d"
                   ]))
@@ -236,9 +246,10 @@ diagnosticsSpec = do
           , mkDiagnostic  (Just "hlint") "c"
           , mkDiagnostic  (Just "ghcmod") "d"
           ]
-      let ds = updateDiagnostics Map.empty (J.Uri "uri") (Just 1) (partitionBySource diags)
-      (getDiagnosticParamsFor 100 ds (J.Uri "uri")) `shouldBe`
-        Just (J.PublishDiagnosticsParams (J.Uri "uri")
+        uri = J.toNormalizedUri $ J.Uri "uri"
+      let ds = updateDiagnostics Map.empty uri (Just 1) (partitionBySource diags)
+      (getDiagnosticParamsFor 100 ds uri) `shouldBe`
+        Just (J.PublishDiagnosticsParams (J.fromNormalizedUri uri)
               (J.List [
                     mkDiagnostic  (Just "ghcmod") "d"
                   , mkDiagnostic  (Just "hlint") "c"
@@ -247,8 +258,8 @@ diagnosticsSpec = do
                   ]))
 
       let ds' = flushBySource ds (Just "hlint")
-      (getDiagnosticParamsFor 100 ds' (J.Uri "uri")) `shouldBe`
-        Just (J.PublishDiagnosticsParams (J.Uri "uri")
+      (getDiagnosticParamsFor 100 ds' uri) `shouldBe`
+        Just (J.PublishDiagnosticsParams (J.fromNormalizedUri uri)
               (J.List [
                      mkDiagnostic  (Just "ghcmod") "d"
                   ,  mkDiagnostic2 (Just "ghcmod") "b"

--- a/test/URIFilePathSpec.hs
+++ b/test/URIFilePathSpec.hs
@@ -22,6 +22,7 @@ spec :: Spec
 spec = do
   describe "URI file path functions" uriFilePathSpec
   describe "file path URI functions" filePathUriSpec
+  describe "URI normalization functions" uriNormalizeSpec
 
 testPosixUri :: Uri
 testPosixUri = Uri $ pack "file:///home/myself/example.hs"
@@ -96,6 +97,12 @@ filePathUriSpec = do
     uri `shouldBe` Uri "file://myself/example.hs"
     let back = platformAwareUriToFilePath "posix" uri
     back `shouldBe` Just relativePosixFilePath
+
+uriNormalizeSpec :: Spec
+uriNormalizeSpec = do
+  it "ignores differences in percent-encoding" $ property $ \uri -> do
+    toNormalizedUri (Uri $ pack $ escapeURIString isUnescapedInURI uri) `shouldBe`
+        toNormalizedUri (Uri $ pack $ escapeURIString (const False) uri)
 
 genWindowsFilePath :: Gen FilePath
 genWindowsFilePath = do


### PR DESCRIPTION
Previously, haskell-lsp treated URIs that only differ in
percent-encoding. This does not comply with the URI spec and it can
also lead to really confusing errors where e.g., a VFS lookup fails
due to using a slightly different percent-encoding.