### PR TITLE
Changed the initial callbacks type to also capture initial config

### DIFF
--- a/haskell-lsp.cabal
+++ b/haskell-lsp.cabal
@@ -111,6 +111,7 @@ test-suite haskell-lsp-test
                        VspSpec
                        WorkspaceEditSpec
                        WorkspaceFoldersSpec
+                       InitialConfigurationSpec
   build-depends:       base
                      , QuickCheck
                      , aeson

--- a/test/InitialConfigurationSpec.hs
+++ b/test/InitialConfigurationSpec.hs
@@ -1,0 +1,63 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module InitialConfigurationSpec where
+
+import           Control.Concurrent.MVar
+import           Control.Concurrent.STM
+import           Data.Aeson
+import           Data.Default
+import           Language.Haskell.LSP.Core
+import           Language.Haskell.LSP.Types
+import           Language.Haskell.LSP.Types.Capabilities
+import           Test.Hspec
+
+spec :: Spec
+spec =
+  describe "initial configuration" $ it "stores initial configuration data" $ do
+
+    lfVar <- newEmptyMVar
+
+    let
+        initialConfigHandler (RequestMessage _ _ Initialize InitializeParams{_initializationOptions = Just opts}) =
+          case (fromJSON opts :: Result String) of
+                Success s -> Right s
+                _         -> Left "Could not decode configuration"
+        initialConfigHandler _ =
+          error "Got the wrong request for the onInitialConfiguration callback"
+
+        initCb :: InitializeCallbacks String
+        initCb = InitializeCallbacks
+          initialConfigHandler
+          (const $ Left "")
+          (\lf -> putMVar lfVar lf >> return Nothing)
+
+        handlers = def
+
+    tvarLspId <- newTVarIO 0
+    tvarCtx   <- newTVarIO $ defaultLanguageContextData handlers
+                                                        def
+                                                        undefined
+                                                        tvarLspId
+                                                        (const $ return ())
+                                                        Nothing
+
+    let putMsg msg =
+          let jsonStr = encode msg in handleMessage initCb tvarCtx jsonStr
+
+    let
+        initParams        = InitializeParams
+          Nothing
+          Nothing
+          (Just (Uri "/foo"))
+          (Just (Data.Aeson.String "configuration"))
+          fullCaps
+          Nothing
+          Nothing
+
+        initMsg :: InitializeRequest
+        initMsg = RequestMessage "2.0" (IdInt 0) Initialize initParams
+
+    putMsg initMsg
+    contents <- readTVarIO tvarCtx
+    resConfig contents  `shouldBe` Just "configuration"
+

--- a/test/WorkspaceFoldersSpec.hs
+++ b/test/WorkspaceFoldersSpec.hs
@@ -12,18 +12,25 @@ import Language.Haskell.LSP.Types.Capabilities
 import Test.Hspec
 
 spec :: Spec
-spec = describe "workspace folders" $
-  it "keeps track of open workspace folders" $ do
+spec =
+  describe "workspace folders" $ it "keeps track of open workspace folders" $ do
 
     lfVar <- newEmptyMVar
 
-    let initCb :: InitializeCallback ()
-        initCb = (const $ Left "", \lf -> putMVar lfVar lf >> return Nothing)
+    let initCb :: InitializeCallbacks ()
+        initCb = InitializeCallbacks
+          (const $ Left "")
+          (const $ Left "")
+          (\lf -> putMVar lfVar lf >> return Nothing)
         handlers = def
 
     tvarLspId <- newTVarIO 0
-    tvarCtx <- newTVarIO $
-      defaultLanguageContextData handlers def undefined tvarLspId (const $ return ()) Nothing
+    tvarCtx   <- newTVarIO $ defaultLanguageContextData handlers
+                                                        def
+                                                        undefined
+                                                        tvarLspId
+                                                        (const $ return ())
+                                                        Nothing
 
     let putMsg msg =
           let jsonStr = encode msg


### PR DESCRIPTION
The initial configuration sent by the client was being ignored. This
changes the types and handlers to read initial configuration and
remember it in the LangaugeContext value