### PR TITLE
Fix shutdown response type

### DIFF
--- a/haskell-lsp-types/src/Language/Haskell/LSP/Types/DataTypesJSON.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/Types/DataTypesJSON.hs
@@ -794,8 +794,8 @@ Response
 
 -}
 
-type ShutdownRequest  = RequestMessage ClientMethod (Maybe A.Value) Text
-type ShutdownResponse = ResponseMessage Text
+type ShutdownRequest  = RequestMessage ClientMethod (Maybe A.Value) (Maybe ())
+type ShutdownResponse = ResponseMessage (Maybe ())
 
 -- ---------------------------------------------------------------------
 {-

--- a/src/Language/Haskell/LSP/Core.hs
+++ b/src/Language/Haskell/LSP/Core.hs
@@ -879,7 +879,7 @@ progressCancelHandler tvarCtx (J.NotificationMessage _ _ (J.ProgressCancelParams
 shutdownRequestHandler :: TVar (LanguageContextData config) -> J.ShutdownRequest -> IO ()
 shutdownRequestHandler tvarCtx req@(J.RequestMessage _ origId _ _) =
   flip E.catches (defaultErrorHandlers tvarCtx (J.responseId origId) req) $ do
-  let res  = makeResponseMessage req "ok"
+  let res  = makeResponseMessage req Nothing
 
   sendResponse tvarCtx $ RspShutdown res
 


### PR DESCRIPTION
It should always be null, so by changing it to (Maybe ()) this allows it a JSON of `response = null` to be decoded.