### PR TITLE
Add ProgressToken to all missing data types

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Revision history for haskell-lsp
 
+## 0.17.0.0 -- unreleased
+
+* Update progress reporting to match the LSP 3.15 specification.
+
 ## 0.16.0.0 -- 2019-09-07
 
 * Add support for CodeActionOptions (@thomasjm)

--- a/haskell-lsp-types/src/Language/Haskell/LSP/Types/CodeAction.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/Types/CodeAction.hs
@@ -14,6 +14,7 @@ import           Language.Haskell.LSP.Types.Diagnostic
 import           Language.Haskell.LSP.Types.List
 import           Language.Haskell.LSP.Types.Location
 import           Language.Haskell.LSP.Types.Message
+import           Language.Haskell.LSP.Types.Progress
 import           Language.Haskell.LSP.Types.TextDocument
 import           Language.Haskell.LSP.Types.WorkspaceEdit
 
@@ -256,6 +257,7 @@ data CodeActionParams =
     { _textDocument :: TextDocumentIdentifier
     , _range        :: Range
     , _context      :: CodeActionContext
+    , _workDoneToken :: Maybe ProgressToken -- ^ An optional token that a server can use to report work done progress.
     } deriving (Read,Show,Eq)
 
 deriveJSON lspOptions ''CodeActionParams

--- a/haskell-lsp-types/src/Language/Haskell/LSP/Types/Completion.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/Types/Completion.hs
@@ -15,6 +15,7 @@ import           Language.Haskell.LSP.Types.List
 import           Language.Haskell.LSP.Types.Location
 import           Language.Haskell.LSP.Types.MarkupContent
 import           Language.Haskell.LSP.Types.Message
+import           Language.Haskell.LSP.Types.Progress
 import           Language.Haskell.LSP.Types.TextDocument
 import           Language.Haskell.LSP.Types.Utils
 import           Language.Haskell.LSP.Types.WorkspaceEdit
@@ -435,6 +436,7 @@ data CompletionParams =
     , _context      :: Maybe CompletionContext
       -- ^ The completion context. This is only available if the client specifies
       -- to send this using `ClientCapabilities.textDocument.completion.contextSupport === true`
+    , _workDoneToken :: Maybe ProgressToken -- ^ An optional token that a server can use to report work done progress.
     }
   deriving (Read, Show, Eq)
 

--- a/haskell-lsp-types/src/Language/Haskell/LSP/Types/DataTypesJSON.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/Types/DataTypesJSON.hs
@@ -2009,9 +2009,10 @@ deriveJSON lspOptions ''ReferenceContext
 
 data ReferenceParams =
   ReferenceParams
-    { _textDocument :: TextDocumentIdentifier
-    , _position     :: Position
-    , _context      :: ReferenceContext
+    { _textDocument  :: TextDocumentIdentifier
+    , _position      :: Position
+    , _context       :: ReferenceContext
+    , _workDoneToken :: Maybe ProgressToken -- ^ An optional token that a server can use to report work done progress.
     } deriving (Read,Show,Eq)
 
 deriveJSON lspOptions ''ReferenceParams

--- a/haskell-lsp-types/src/Language/Haskell/LSP/Types/DataTypesJSON.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/Types/DataTypesJSON.hs
@@ -27,6 +27,7 @@ import           Language.Haskell.LSP.Types.List
 import           Language.Haskell.LSP.Types.Location
 import           Language.Haskell.LSP.Types.MarkupContent
 import           Language.Haskell.LSP.Types.Message
+import           Language.Haskell.LSP.Types.Progress
 import           Language.Haskell.LSP.Types.Symbol
 import           Language.Haskell.LSP.Types.TextDocument
 import           Language.Haskell.LSP.Types.Uri
@@ -2151,7 +2152,8 @@ Response
 
 data WorkspaceSymbolParams =
   WorkspaceSymbolParams
-    { _query :: Text
+    { _query :: Text -- ^ A query string to filter symbols by. Clients may send an empty string here to request all symbols.
+    , _workDoneToken :: Maybe ProgressToken -- ^ An optional token that a server can use to report work done progress.
     } deriving (Read,Show,Eq)
 
 deriveJSON lspOptions ''WorkspaceSymbolParams
@@ -2736,8 +2738,9 @@ export interface ExecuteCommandRegistrationOptions {
 
 data ExecuteCommandParams =
   ExecuteCommandParams
-    { _command   :: Text
-    , _arguments :: Maybe (List A.Value)
+    { _command   :: Text -- ^ The identifier of the actual command handler.
+    , _arguments :: Maybe (List A.Value) -- ^ Arguments that the command should be invoked with.
+    , _workDoneToken :: Maybe ProgressToken -- ^ An optional token that a server can use to report work done progress.
     } deriving (Show, Read, Eq)
 
 deriveJSON lspOptions ''ExecuteCommandParams

--- a/haskell-lsp-types/src/Language/Haskell/LSP/Types/DataTypesJSON.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/Types/DataTypesJSON.hs
@@ -2218,6 +2218,7 @@ interface CodeLens {
 data CodeLensParams =
   CodeLensParams
     { _textDocument :: TextDocumentIdentifier
+    , _workDoneToken :: Maybe ProgressToken -- ^ An optional token that a server can use to report work done progress.
     } deriving (Read,Show,Eq)
 
 deriveJSON lspOptions ''CodeLensParams
@@ -2340,6 +2341,7 @@ export interface DocumentLinkRegistrationOptions extends TextDocumentRegistratio
 data DocumentLinkParams =
   DocumentLinkParams
     { _textDocument :: TextDocumentIdentifier
+    , _workDoneToken :: Maybe ProgressToken -- ^ An optional token that a server can use to report work done progress.
     } deriving (Read,Show,Eq)
 
 deriveJSON lspOptions ''DocumentLinkParams
@@ -2448,6 +2450,7 @@ data DocumentFormattingParams =
   DocumentFormattingParams
     { _textDocument :: TextDocumentIdentifier
     , _options      :: FormattingOptions
+    , _workDoneToken :: Maybe ProgressToken -- ^ An optional token that a server can use to report work done progress.
     } deriving (Show,Read,Eq)
 
 deriveJSON lspOptions ''DocumentFormattingParams
@@ -2499,6 +2502,7 @@ data DocumentRangeFormattingParams =
     { _textDocument :: TextDocumentIdentifier
     , _range        :: Range
     , _options      :: FormattingOptions
+    , _workDoneToken :: Maybe ProgressToken -- ^ An optional token that a server can use to report work done progress.
     } deriving (Read,Show,Eq)
 
 deriveJSON lspOptions ''DocumentRangeFormattingParams
@@ -2630,6 +2634,7 @@ data RenameParams =
     { _textDocument :: TextDocumentIdentifier
     , _position     :: Position
     , _newName      :: Text
+    , _workDoneToken :: Maybe ProgressToken -- ^ An optional token that a server can use to report work done progress.
     } deriving (Show, Read, Eq)
 
 deriveJSON lspOptions ''RenameParams

--- a/haskell-lsp-types/src/Language/Haskell/LSP/Types/Progress.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/Types/Progress.hs
@@ -3,6 +3,9 @@ module Language.Haskell.LSP.Types.Progress where
 import qualified Data.Aeson as A
 import Data.Text (Text)
 
+-- | A token used to report progress back or return partial results for a
+-- specific request.
+-- @since 0.17.0.0
 data ProgressToken
     = ProgressNumericToken Int
     | ProgressTextToken Text

--- a/haskell-lsp-types/src/Language/Haskell/LSP/Types/Symbol.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/Types/Symbol.hs
@@ -12,6 +12,7 @@ import           Language.Haskell.LSP.Types.TextDocument
 import           Language.Haskell.LSP.Types.List
 import           Language.Haskell.LSP.Types.Location
 import           Language.Haskell.LSP.Types.Message
+import           Language.Haskell.LSP.Types.Progress
 
 -- ---------------------------------------------------------------------
 {-
@@ -102,6 +103,7 @@ Registration Options: TextDocumentRegistrationOptions
 data DocumentSymbolParams =
   DocumentSymbolParams
     { _textDocument :: TextDocumentIdentifier
+    , _workDoneToken :: Maybe ProgressToken -- ^ An optional token that a server can use to report work done progress.
     } deriving (Read,Show,Eq)
 
 deriveJSON lspOptions ''DocumentSymbolParams


### PR DESCRIPTION
This is based on @bubba’s branch. I’ve gone through all types in the specification and added it so this should be exhaustive (ignoring types that are completely missing in `haskell-lsp` atm, e.g., `PrepareRenameParams`).

fixes #186 