### PR TITLE
Ensure that ResponseMessage has either a result or an error

### DIFF
--- a/test/JsonSpec.hs
+++ b/test/JsonSpec.hs
@@ -64,11 +64,18 @@ instance Arbitrary HoverContents where
 
 instance Arbitrary a => Arbitrary (ResponseMessage a) where
   arbitrary =
-    ResponseMessage
-      <$> arbitrary
-      <*> arbitrary
-      <*> arbitrary
-      <*> arbitrary
+    oneof
+      [ ResponseMessage
+          <$> arbitrary
+          <*> arbitrary
+          <*> (Just <$> arbitrary)
+          <*> pure Nothing
+      , ResponseMessage
+          <$> arbitrary
+          <*> arbitrary
+          <*> pure Nothing
+          <*> (Just <$> arbitrary)
+      ]
 
 instance Arbitrary LspIdRsp where
   arbitrary = oneof [IdRspInt <$> arbitrary, IdRspString <$> arbitrary, pure IdRspNull]


### PR DESCRIPTION
Without this, it can happen that a request is parsed as a response
with both _result and _error set to Nothing. This has caused issues
for me with lsp-test which listens for a response message with the
same id after sending a request but actually ended up interpreting a
request send from the server as a response.