### PR TITLE
Fix response type for CodeLensResolve

### DIFF
--- a/haskell-lsp-types/src/Language/Haskell/LSP/Types/DataTypesJSON.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/Types/DataTypesJSON.hs
@@ -2319,8 +2319,8 @@ Response
 
 -}
 
-type CodeLensResolveRequest  = RequestMessage ClientMethod CodeLens (List CodeLens)
-type CodeLensResolveResponse = ResponseMessage (List CodeLens)
+type CodeLensResolveRequest  = RequestMessage ClientMethod CodeLens CodeLens
+type CodeLensResolveResponse = ResponseMessage CodeLens
 
 -- ---------------------------------------------------------------------
 {-

--- a/haskell-lsp-types/src/Language/Haskell/LSP/Types/Message.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/Types/Message.hs
@@ -322,6 +322,7 @@ export namespace ErrorCodes {
 
         // Defined by the protocol.
         export const RequestCancelled: number = -32800;
+        export const ContentModified: number = -32801;
 }
 -}
 
@@ -335,6 +336,7 @@ data ErrorCode = ParseError
                | ServerNotInitialized
                | UnknownErrorCode
                | RequestCancelled
+               | ContentModified
                -- ^ Note: server error codes are reserved from -32099 to -32000
                deriving (Read,Show,Eq)
 
@@ -349,6 +351,7 @@ instance A.ToJSON ErrorCode where
   toJSON ServerNotInitialized = A.Number (-32002)
   toJSON UnknownErrorCode     = A.Number (-32001)
   toJSON RequestCancelled     = A.Number (-32800)
+  toJSON ContentModified      = A.Number (-32801)
 
 instance A.FromJSON ErrorCode where
   parseJSON (A.Number (-32700)) = pure ParseError
@@ -361,6 +364,7 @@ instance A.FromJSON ErrorCode where
   parseJSON (A.Number (-32002)) = pure ServerNotInitialized
   parseJSON (A.Number (-32001)) = pure UnknownErrorCode
   parseJSON (A.Number (-32800)) = pure RequestCancelled
+  parseJSON (A.Number (-32801)) = pure ContentModified
   parseJSON _                   = mempty
 
 -- -------------------------------------

--- a/test/JsonSpec.hs
+++ b/test/JsonSpec.hs
@@ -96,6 +96,7 @@ instance Arbitrary ErrorCode where
       , ServerNotInitialized
       , UnknownErrorCode
       , RequestCancelled
+      , ContentModified
       ]
 
 -- | make lists of maximum length 3 for test performance


### PR DESCRIPTION
Firstly, sorry for bundling two changes in this PR. I'm happy to split them into separate changes if you'd prefer, they were just sufficiently small I wasn't sure if it was worth it:

 - Change `codeLens/resolve` to respond with a single code lens. Unlike the normal `textDocument/codeLens` request, [resolving should only return a single lens][clr].
 - Add the `ContentModified` error code, as described in [the spec][contentmodified].

[clr]: https://microsoft.github.io/language-server-protocol/specifications/specification-3-14/#codeLens_resolve
[contentmodified]: https://microsoft.github.io/language-server-protocol/specifications/specification-3-14/#response-message