### PR TITLE
Fixes to persistVirtualFile

### DIFF
--- a/src/Language/Haskell/LSP/VFS.hs
+++ b/src/Language/Haskell/LSP/VFS.hs
@@ -166,7 +166,9 @@ changeFromServerVFS initVfs (J.RequestMessage _ _ _ params) = do
 -- ---------------------------------------------------------------------
 virtualFileName :: FilePath -> J.NormalizedUri -> VirtualFile -> FilePath
 virtualFileName prefix uri (VirtualFile _ file_ver _) =
-  prefix </> show (hash (J.fromNormalizedUri uri)) ++ "-" ++ show file_ver ++ ".hs"
+  let uri_raw = J.fromNormalizedUri uri
+      basename = maybe "" takeFileName (J.uriToFilePath uri_raw)
+  in prefix </> show (hash uri_raw) ++ "-" ++ show file_ver ++ "-" ++ basename ++ ".hs"
 
 -- | Write a virtual file to a temporary file if it exists in the VFS.
 persistFileVFS :: VFS -> J.NormalizedUri -> Maybe (FilePath, IO ())

--- a/src/Language/Haskell/LSP/VFS.hs
+++ b/src/Language/Haskell/LSP/VFS.hs
@@ -168,7 +168,14 @@ virtualFileName :: FilePath -> J.NormalizedUri -> VirtualFile -> FilePath
 virtualFileName prefix uri (VirtualFile _ file_ver _) =
   let uri_raw = J.fromNormalizedUri uri
       basename = maybe "" takeFileName (J.uriToFilePath uri_raw)
-  in prefix </> show (hash uri_raw) ++ "-" ++ show file_ver ++ "-" ++ basename ++ ".hs"
+      -- Given a length and a version number, pad the version number to
+      -- the given n. Does nothing if the version number string is longer
+      -- than the given length.
+      padLeft :: Int -> Int -> String
+      padLeft n num =
+        let numString = show num
+        in replicate (n - length numString) '0' ++ numString
+  in prefix </> basename ++ "-" ++ padLeft 5 file_ver ++ "-" ++ show (hash uri_raw) ++ ".hs"
 
 -- | Write a virtual file to a temporary file if it exists in the VFS.
 persistFileVFS :: VFS -> J.NormalizedUri -> Maybe (FilePath, IO ())

--- a/test/VspSpec.hs
+++ b/test/VspSpec.hs
@@ -31,7 +31,7 @@ mkRange :: Int -> Int -> Int -> Int -> Maybe J.Range
 mkRange ls cs le ce = Just $ J.Range (J.Position ls cs) (J.Position le ce)
 
 vfsFromText :: T.Text -> VirtualFile
-vfsFromText text = VirtualFile 0 (Rope.fromText text)
+vfsFromText text = VirtualFile 0 0 (Rope.fromText text)
 
 -- ---------------------------------------------------------------------
 


### PR DESCRIPTION
1. Make it return a `Maybe` when the file does not exist in the VFS
2. Use an monotonically incrementing counter to keep track of the version rather than relying on the LSP version which has no guarantees about monotonicity. 