### PR TITLE
Normalize file paths before converting to Uri's

### DIFF
--- a/haskell-lsp-types/src/Language/Haskell/LSP/Types/Uri.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/Types/Uri.hs
@@ -27,8 +27,10 @@ newtype NormalizedUri = NormalizedUri Text
   deriving (Eq,Ord,Read,Show,Generic,Hashable)
 
 toNormalizedUri :: Uri -> NormalizedUri
-toNormalizedUri (Uri t) =
+toNormalizedUri uri =
     NormalizedUri $ T.pack $ escapeURIString isUnescapedInURI $ unEscapeString $ T.unpack t
+  where (Uri t) = maybe uri filePathToUri (uriToFilePath uri)
+        -- To ensure all `Uri`s have the file path like the created ones by `filePathToUri`
 
 fromNormalizedUri :: NormalizedUri -> Uri
 fromNormalizedUri (NormalizedUri t) = Uri t

--- a/haskell-lsp-types/src/Language/Haskell/LSP/Types/Uri.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/Types/Uri.hs
@@ -86,6 +86,8 @@ platformAdjustToUriPath systemOS srcPath
     (splitDirectories, splitDrive)
       | systemOS == windowsOS =
           (FPW.splitDirectories, (\(f,s)-> (map toUpper f, s)) . FPW.splitDrive)
+          -- We ensure the driver letter is upper case for windows to make `c:\` and `C:\` equivalent
+          -- See https://tools.ietf.org/html/rfc8089#page-13
       | otherwise =
           (FPP.splitDirectories, FPP.splitDrive)
     escapedPath =

--- a/haskell-lsp-types/src/Language/Haskell/LSP/Types/Uri.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/Types/Uri.hs
@@ -5,13 +5,11 @@ module Language.Haskell.LSP.Types.Uri where
 
 import           Control.DeepSeq
 import qualified Data.Aeson                                 as A
-import           Data.Char                                  (toUpper)
 import           Data.Hashable
 import           Data.Text                                  (Text)
 import qualified Data.Text                                  as T
 import           GHC.Generics
 import           Network.URI hiding (authority)
-import qualified System.FilePath                            as FP
 import qualified System.FilePath.Posix                      as FPP
 import qualified System.FilePath.Windows                    as FPW
 import qualified System.Info

--- a/haskell-lsp-types/src/Language/Haskell/LSP/Types/Uri.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/Types/Uri.hs
@@ -5,6 +5,7 @@ module Language.Haskell.LSP.Types.Uri where
 
 import           Control.DeepSeq
 import qualified Data.Aeson                                 as A
+import           Data.Char                                  (toUpper)
 import           Data.Hashable
 import           Data.Text                                  (Text)
 import qualified Data.Text                                  as T
@@ -83,8 +84,10 @@ platformAdjustToUriPath systemOS srcPath
   | otherwise = escapedPath
   where
     (splitDirectories, splitDrive)
-      | systemOS == windowsOS = (FPW.splitDirectories, FPW.splitDrive)
-      | otherwise = (FPP.splitDirectories, FPP.splitDrive)
+      | systemOS == windowsOS =
+          (FPW.splitDirectories, (\(f,s)-> (map toUpper f, s)) . FPW.splitDrive)
+      | otherwise =
+          (FPP.splitDirectories, FPP.splitDrive)
     escapedPath =
         case splitDrive srcPath of
             (drv, rest) ->
@@ -94,7 +97,7 @@ platformAdjustToUriPath systemOS srcPath
     -- we do a final replacement of \ to /
     convertDrive drv
       | systemOS == windowsOS && FPW.hasTrailingPathSeparator drv =
-        FPP.addTrailingPathSeparator (init drv)
+          FPP.addTrailingPathSeparator (init drv)
       | otherwise = drv
     unescaped c
       | systemOS == windowsOS = isUnreserved c || c `elem` [':', '\\', '/']

--- a/test/URIFilePathSpec.hs
+++ b/test/URIFilePathSpec.hs
@@ -12,7 +12,7 @@ import qualified System.FilePath.Windows as FPW
 import Test.Hspec
 import Test.QuickCheck
 #if !MIN_VERSION_QuickCheck(2,10,0)
-import Data.Char                               (GeneralCategory(..), generalCategory)
+import Data.Char                              (GeneralCategory(..), generalCategory)
 #endif
 
 -- ---------------------------------------------------------------------

--- a/test/URIFilePathSpec.hs
+++ b/test/URIFilePathSpec.hs
@@ -133,7 +133,9 @@ genWindowsFilePath = do
     pathSep <- elements ['/', '\\']
     driveLetter <- elements ["C:", "c:"]
     pure (driveLetter <> [pathSep] <> intercalate [pathSep] segments)
-  where pathSegment = listOf1 (arbitraryUnicodeChar `suchThat` (`notElem` ['/', '\\', ':']))
+  where pathSegment = listOf1 (validUnicodeChar `suchThat` (`notElem` ['/', '\\', ':']))
+        validUnicodeChar = arbitraryUnicodeChar `suchThat` isValidUnicodeChar
+        isValidUnicodeChar x = x /= '\65534' && x /= '\65535'
 
 genPosixFilePath :: Gen FilePath
 genPosixFilePath = do

--- a/test/URIFilePathSpec.hs
+++ b/test/URIFilePathSpec.hs
@@ -133,15 +133,17 @@ genWindowsFilePath = do
     pathSep <- elements ['/', '\\']
     driveLetter <- elements ["C:", "c:"]
     pure (driveLetter <> [pathSep] <> intercalate [pathSep] segments)
-  where pathSegment = listOf1 (validUnicodeChar `suchThat` (`notElem` ['/', '\\', ':']))
-        validUnicodeChar = arbitraryUnicodeChar `suchThat` isValidUnicodeChar
-        isValidUnicodeChar x = x /= '\65534' && x /= '\65535'
+  where pathSegment = listOf1 (genValidUnicodeChar `suchThat` (`notElem` ['/', '\\', ':']))
 
 genPosixFilePath :: Gen FilePath
 genPosixFilePath = do
     segments <- listOf pathSegment
     pure ("/" <> intercalate "/" segments)
-  where pathSegment = listOf1 (arbitraryUnicodeChar `suchThat` (`notElem` ['/']))
+  where pathSegment = listOf1 (genValidUnicodeChar `suchThat` (`notElem` ['/']))
+
+genValidUnicodeChar :: Gen Char
+genValidUnicodeChar = arbitraryUnicodeChar `suchThat` isCharacter
+  where isCharacter x = x /= '\65534' && x /= '\65535'
 
 #if !MIN_VERSION_QuickCheck(2,10,0)
 arbitraryUnicodeChar :: Gen Char

--- a/test/URIFilePathSpec.hs
+++ b/test/URIFilePathSpec.hs
@@ -34,10 +34,13 @@ relativePosixFilePath :: FilePath
 relativePosixFilePath = "myself/example.hs"
 
 testWindowsUri :: Uri
-testWindowsUri = Uri $ pack "file:///c:/Users/myself/example.hs"
+testWindowsUri = Uri $ pack "file:///C:/Users/myself/example.hs"
 
 testWindowsFilePath :: FilePath
-testWindowsFilePath = "c:\\Users\\myself\\example.hs"
+testWindowsFilePath = "C:\\Users\\myself\\example.hs"
+
+testWindowsFilePathDriveLowerCase :: FilePath
+testWindowsFilePathDriveLowerCase = "c:\\Users\\myself\\example.hs"
 
 uriFilePathSpec :: Spec
 uriFilePathSpec = do
@@ -57,6 +60,10 @@ uriFilePathSpec = do
     let theUri = platformAwareFilePathToUri windowsOS testWindowsFilePath
     theUri `shouldBe` testWindowsUri
 
+  it "make the drive letter upper case when converting a Windows file path to a URI" $ do
+    let theUri = platformAwareFilePathToUri windowsOS testWindowsFilePathDriveLowerCase
+    theUri `shouldBe` testWindowsUri
+
 filePathUriSpec :: Spec
 filePathUriSpec = do
   it "converts a POSIX file path to a URI" $ do
@@ -69,7 +76,7 @@ filePathUriSpec = do
 
   it "converts a Windows file path to a URI" $ do
     let theFilePath = platformAwareFilePathToUri windowsOS "c:/Functional.hs"
-    theFilePath `shouldBe` (Uri "file:///c:/Functional.hs")
+    theFilePath `shouldBe` (Uri "file:///C:/Functional.hs")
 
   it "converts a POSIX file path to a URI and back" $ do
     let theFilePath = platformAwareFilePathToUri "posix" "./Functional.hs"
@@ -108,7 +115,8 @@ genWindowsFilePath :: Gen FilePath
 genWindowsFilePath = do
     segments <- listOf pathSegment
     pathSep <- elements ['/', '\\']
-    pure ("C:" <> [pathSep] <> intercalate [pathSep] segments)
+    driveLetter <- elements ["C:", "c:"]
+    pure (driveLetter <> [pathSep] <> intercalate [pathSep] segments)
   where pathSegment = listOf1 (arbitraryASCIIChar `suchThat` (`notElem` ['/', '\\', '.', ':']))
 
 genPosixFilePath :: Gen FilePath


### PR DESCRIPTION
* In hie we've detected some VFS missings cause the key used to lookup the map only differed in the drive letter case: https://github.com/mpickering/haskell-ide-engine/issues/64#issuecomment-558136150
* The standard somewhat recommends make the drive letter upper case to avoid those issues: https://tools.ietf.org/html/rfc8089#page-13
* The code to normalize the filepaths before converting in URI is similar to the function `System.FilePath.normalise` (including make the driver letter upper case) but when i tried to use it some test cases failed so i am not sure if its use was avoided by design.