### PR TITLE
Fix vfs line endings

### DIFF
--- a/src/Language/Haskell/LSP/VFS.hs
+++ b/src/Language/Haskell/LSP/VFS.hs
@@ -57,6 +57,7 @@ import           Language.Haskell.LSP.Utility
 import           System.FilePath
 import           Data.Hashable
 import           System.Directory
+import           System.IO 
 import           System.IO.Temp
 
 -- ---------------------------------------------------------------------
@@ -188,9 +189,13 @@ persistFileVFS vfs uri =
             exists <- doesFileExist tfn
             unless exists $ do
                let contents = Rope.toString (_text vf)
+                   writeRaw h = do
+                    -- We honour the line endings of the original file
+                    hSetNewlineMode h noNewlineTranslation
+                    hPutStr h contents
                logs  $ "haskell-lsp:persistFileVFS: Writing virtual file: " 
-                    ++ "uri = " ++ show uri ++ ", virtual file =" ++ show tfn
-               writeFile tfn contents
+                    ++ "uri = " ++ show uri ++ ", virtual file = " ++ show tfn
+               withFile tfn WriteMode writeRaw
       in Just (tfn, action)
 
 -- ---------------------------------------------------------------------

--- a/src/Language/Haskell/LSP/VFS.hs
+++ b/src/Language/Haskell/LSP/VFS.hs
@@ -190,7 +190,7 @@ persistFileVFS vfs uri =
             unless exists $ do
                let contents = Rope.toString (_text vf)
                    writeRaw h = do
-                    -- We honour the line endings of the original file
+                    -- We honour original file line endings
                     hSetNewlineMode h noNewlineTranslation
                     hPutStr h contents
                logs  $ "haskell-lsp:persistFileVFS: Writing virtual file: " 

--- a/src/Language/Haskell/LSP/VFS.hs
+++ b/src/Language/Haskell/LSP/VFS.hs
@@ -186,7 +186,11 @@ persistFileVFS vfs uri =
       let tfn = virtualFileName (vfsTempDir vfs) uri vf
           action = do
             exists <- doesFileExist tfn
-            unless exists (writeFile tfn (Rope.toString (_text vf)))
+            unless exists $ do
+               let contents = Rope.toString (_text vf)
+               logs  $ "haskell-lsp:persistFileVFS: Writing virtual file: " 
+                    ++ "uri = " ++ show uri ++ ", virtual file =" ++ show tfn
+               writeFile tfn contents
       in Just (tfn, action)
 
 -- ---------------------------------------------------------------------


### PR DESCRIPTION
* Hopefully it will fix https://github.com/haskell/haskell-ide-engine/issues/1478
* vscode (and most editors) let windows users to have files with windows line endings (CRLF) or unix ones (LF)
* [From `System.IO`](http://hackage.haskell.org/package/base-4.12.0.0/docs/System-IO.html#g:25) : 
> The default NewlineMode for a Handle is nativeNewlineMode, which does no translation on Unix systems, but translates '\r\n' to '\n' and back on Windows.
* So if the contents has already `\r\n` it duplicates the line endings
* Imo the sensible option is to honour original file line endings to avoid sync problems 