### PR TITLE
Move "Semigroup WorkspaceEdit" instance

### DIFF
--- a/haskell-lsp-types/src/Language/Haskell/LSP/Types/WorkspaceEdit.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/Types/WorkspaceEdit.hs
@@ -153,12 +153,12 @@ instance Monoid WorkspaceEdit where
   mempty = WorkspaceEdit Nothing Nothing
   mappend (WorkspaceEdit a b) (WorkspaceEdit c d) = WorkspaceEdit (a <> c) (b <> d)
 
-deriveJSON lspOptions ''WorkspaceEdit
-
 #if __GLASGOW_HASKELL__ >= 804
 instance Semigroup WorkspaceEdit where
   (<>) = mappend
 #endif
+
+deriveJSON lspOptions ''WorkspaceEdit
 
 -- ---------------------------------------------------------------------
 


### PR DESCRIPTION
Declaring the instance after the TH splice caused GHC to not be able to see the Semigroup instance needed for the Monoid instance.