### PR TITLE
Store a hash in a NormalizedUri

### DIFF
--- a/haskell-lsp-types/src/Language/Haskell/LSP/Types/Uri.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/Types/Uri.hs
@@ -25,7 +25,7 @@ instance NFData Uri
 --
 -- If you care about performance then you should use a hash map. The keys
 -- are cached in order to make hashing very fast.
-data NormalizedUri = NormalizedUri Int !Text
+data NormalizedUri = NormalizedUri !Int !Text
   deriving (Read,Show,Generic, Eq)
 
 -- Slow but compares paths alphabetically as you would expect.

--- a/haskell-lsp-types/src/Language/Haskell/LSP/Types/Uri.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/Types/Uri.hs
@@ -22,17 +22,27 @@ instance NFData Uri
 -- | When URIs are supposed to be used as keys, it is important to normalize
 -- the percent encoding in the URI since URIs that only differ
 -- when it comes to the percent-encoding should be treated as equivalent.
-newtype NormalizedUri = NormalizedUri Text
-  deriving (Eq,Ord,Read,Show,Generic,Hashable)
+--
+-- If you care about performance then you should use a hash map. The keys
+-- are cached in order to make hashing very fast.
+data NormalizedUri = NormalizedUri Int !Text
+  deriving (Read,Show,Generic, Eq)
+
+-- Slow but compares paths alphabetically as you would expect.
+instance Ord NormalizedUri where
+  compare (NormalizedUri _ u1) (NormalizedUri _ u2) = compare u1 u2
+
+instance Hashable NormalizedUri where
+  hash (NormalizedUri h _) = h
 
 toNormalizedUri :: Uri -> NormalizedUri
-toNormalizedUri uri =
-    NormalizedUri $ T.pack $ escapeURIString isUnescapedInURI $ unEscapeString $ T.unpack t
+toNormalizedUri uri = NormalizedUri (hash norm) norm
   where (Uri t) = maybe uri filePathToUri (uriToFilePath uri)
         -- To ensure all `Uri`s have the file path like the created ones by `filePathToUri`
+        norm = T.pack $ escapeURIString isUnescapedInURI $ unEscapeString $ T.unpack t
 
 fromNormalizedUri :: NormalizedUri -> Uri
-fromNormalizedUri (NormalizedUri t) = Uri t
+fromNormalizedUri (NormalizedUri _ t) = Uri t
 
 fileScheme :: String
 fileScheme = "file:"

--- a/haskell-lsp.cabal
+++ b/haskell-lsp.cabal
@@ -131,6 +131,7 @@ test-suite haskell-lsp-test
                      , sorted-list == 0.2.1.*
                      , stm
                      , text
+                     , unordered-containers
                      -- For GHCI tests
                      -- , async
                      -- , haskell-lsp-types

--- a/src/Language/Haskell/LSP/Core.hs
+++ b/src/Language/Haskell/LSP/Core.hs
@@ -1010,7 +1010,7 @@ flushDiagnosticsBySource tvarDat maxDiagnosticCount msource = join $ atomically 
   let ds = flushBySource (resDiagnostics ctx) msource
   writeTVar tvarDat $ ctx {resDiagnostics = ds}
   -- Send the updated diagnostics to the client
-  return $ forM_ (Map.keys ds) $ \uri -> do
+  return $ forM_ (HM.keys ds) $ \uri -> do
     -- logs $ "haskell-lsp:flushDiagnosticsBySource:uri=" ++ show uri
     let mdp = getDiagnosticParamsFor maxDiagnosticCount ds uri
     case mdp of

--- a/test/DiagnosticsSpec.hs
+++ b/test/DiagnosticsSpec.hs
@@ -3,6 +3,7 @@ module DiagnosticsSpec where
 
 
 import qualified Data.Map                              as Map
+import qualified Data.HashMap.Strict                   as HM
 import qualified Data.SortedList                       as SL
 import           Data.Text                             (Text)
 import           Language.Haskell.LSP.Diagnostics
@@ -55,8 +56,8 @@ diagnosticsSpec = do
           , mkDiagnostic (Just "hlint") "b"
           ]
         uri = J.toNormalizedUri $ J.Uri "uri"
-      (updateDiagnostics Map.empty uri Nothing (partitionBySource diags)) `shouldBe`
-        Map.fromList
+      (updateDiagnostics HM.empty uri Nothing (partitionBySource diags)) `shouldBe`
+        HM.fromList
           [ (uri,StoreItem Nothing $ Map.fromList [(Just "hlint", SL.toSortedList diags) ] )
           ]
 
@@ -69,8 +70,8 @@ diagnosticsSpec = do
           , mkDiagnostic (Just "ghcmod") "b"
           ]
         uri = J.toNormalizedUri $ J.Uri "uri"
-      (updateDiagnostics Map.empty uri Nothing (partitionBySource diags)) `shouldBe`
-        Map.fromList
+      (updateDiagnostics HM.empty uri Nothing (partitionBySource diags)) `shouldBe`
+        HM.fromList
           [ (uri,StoreItem Nothing $ Map.fromList
                 [(Just "hlint",  SL.singleton (mkDiagnostic (Just "hlint")  "a"))
                 ,(Just "ghcmod", SL.singleton (mkDiagnostic (Just "ghcmod") "b"))
@@ -86,8 +87,8 @@ diagnosticsSpec = do
           , mkDiagnostic (Just "ghcmod") "b"
           ]
         uri = J.toNormalizedUri $ J.Uri "uri"
-      (updateDiagnostics Map.empty uri (Just 1) (partitionBySource diags)) `shouldBe`
-        Map.fromList
+      (updateDiagnostics HM.empty uri (Just 1) (partitionBySource diags)) `shouldBe`
+        HM.fromList
           [ (uri,StoreItem (Just 1) $ Map.fromList
                 [(Just "hlint",  SL.singleton (mkDiagnostic (Just "hlint")  "a"))
                 ,(Just "ghcmod", SL.singleton (mkDiagnostic (Just "ghcmod") "b"))
@@ -107,9 +108,9 @@ diagnosticsSpec = do
           [ mkDiagnostic (Just "hlint") "a2"
           ]
         uri = J.toNormalizedUri $ J.Uri "uri"
-      let origStore = updateDiagnostics Map.empty uri Nothing (partitionBySource diags1)
+      let origStore = updateDiagnostics HM.empty uri Nothing (partitionBySource diags1)
       (updateDiagnostics origStore uri Nothing (partitionBySource diags2)) `shouldBe`
-        Map.fromList
+        HM.fromList
           [ (uri,StoreItem Nothing $ Map.fromList [(Just "hlint", SL.toSortedList diags2) ] )
           ]
 
@@ -125,9 +126,9 @@ diagnosticsSpec = do
           [ mkDiagnostic (Just "hlint") "a2"
           ]
         uri = J.toNormalizedUri $ J.Uri "uri"
-      let origStore = updateDiagnostics Map.empty uri Nothing (partitionBySource diags1)
+      let origStore = updateDiagnostics HM.empty uri Nothing (partitionBySource diags1)
       (updateDiagnostics origStore uri Nothing (partitionBySource diags2)) `shouldBe`
-        Map.fromList
+        HM.fromList
           [ (uri,StoreItem Nothing $ Map.fromList
                 [(Just "hlint",  SL.singleton (mkDiagnostic (Just "hlint")  "a2"))
                 ,(Just "ghcmod", SL.singleton (mkDiagnostic (Just "ghcmod") "b1"))
@@ -143,9 +144,9 @@ diagnosticsSpec = do
           , mkDiagnostic (Just "ghcmod") "b1"
           ]
         uri = J.toNormalizedUri $ J.Uri "uri"
-      let origStore = updateDiagnostics Map.empty uri Nothing (partitionBySource diags1)
+      let origStore = updateDiagnostics HM.empty uri Nothing (partitionBySource diags1)
       (updateDiagnostics origStore uri Nothing (Map.fromList [(Just "ghcmod",SL.toSortedList [])])) `shouldBe`
-        Map.fromList
+        HM.fromList
           [ (uri,StoreItem Nothing $ Map.fromList
                 [(Just "ghcmod", SL.toSortedList [])
                 ,(Just "hlint",  SL.singleton (mkDiagnostic (Just "hlint")  "a1"))
@@ -166,9 +167,9 @@ diagnosticsSpec = do
           [ mkDiagnostic (Just "hlint") "a2"
           ]
         uri = J.toNormalizedUri $ J.Uri "uri"
-      let origStore = updateDiagnostics Map.empty uri (Just 1) (partitionBySource diags1)
+      let origStore = updateDiagnostics HM.empty uri (Just 1) (partitionBySource diags1)
       (updateDiagnostics origStore uri (Just 2) (partitionBySource diags2)) `shouldBe`
-        Map.fromList
+        HM.fromList
           [ (uri,StoreItem (Just 2) $ Map.fromList [(Just "hlint", SL.toSortedList diags2) ] )
           ]
 
@@ -184,9 +185,9 @@ diagnosticsSpec = do
           [ mkDiagnostic (Just "hlint") "a2"
           ]
         uri = J.toNormalizedUri $ J.Uri "uri"
-      let origStore = updateDiagnostics Map.empty uri (Just 1) (partitionBySource diags1)
+      let origStore = updateDiagnostics HM.empty uri (Just 1) (partitionBySource diags1)
       (updateDiagnostics origStore uri (Just 2) (partitionBySource diags2)) `shouldBe`
-        Map.fromList
+        HM.fromList
           [ (uri,StoreItem (Just 2) $ Map.fromList
                 [(Just "hlint", SL.singleton (mkDiagnostic (Just "hlint")  "a2"))
               ] )
@@ -203,7 +204,7 @@ diagnosticsSpec = do
           , mkDiagnostic (Just "ghcmod") "b"
           ]
         uri = J.toNormalizedUri $ J.Uri "uri"
-      let ds = updateDiagnostics Map.empty uri (Just 1) (partitionBySource diags)
+      let ds = updateDiagnostics HM.empty uri (Just 1) (partitionBySource diags)
       (getDiagnosticParamsFor 10 ds uri) `shouldBe`
         Just (J.PublishDiagnosticsParams (J.fromNormalizedUri uri) (J.List $ reverse diags))
 
@@ -220,7 +221,7 @@ diagnosticsSpec = do
           , mkDiagnostic  (Just "ghcmod") "d"
           ]
         uri = J.toNormalizedUri $ J.Uri "uri"
-      let ds = updateDiagnostics Map.empty uri (Just 1) (partitionBySource diags)
+      let ds = updateDiagnostics HM.empty uri (Just 1) (partitionBySource diags)
       (getDiagnosticParamsFor 2 ds uri) `shouldBe`
         Just (J.PublishDiagnosticsParams (J.fromNormalizedUri uri)
               (J.List [
@@ -247,7 +248,7 @@ diagnosticsSpec = do
           , mkDiagnostic  (Just "ghcmod") "d"
           ]
         uri = J.toNormalizedUri $ J.Uri "uri"
-      let ds = updateDiagnostics Map.empty uri (Just 1) (partitionBySource diags)
+      let ds = updateDiagnostics HM.empty uri (Just 1) (partitionBySource diags)
       (getDiagnosticParamsFor 100 ds uri) `shouldBe`
         Just (J.PublishDiagnosticsParams (J.fromNormalizedUri uri)
               (J.List [


### PR DESCRIPTION
NormalizedUris are supposed to be used as keys in maps. Using a HashMap
with a cached key is far faster than using a Map with the slow ordering
instance.

In particular, ghcide was hammering updateDiagnostics and the `compare`
function for `NormalizedUri` was dominating the profile.