### PR TITLE
Force utf8 encoding when writing vfs temp files

### DIFF
--- a/src/Language/Haskell/LSP/VFS.hs
+++ b/src/Language/Haskell/LSP/VFS.hs
@@ -192,6 +192,7 @@ persistFileVFS vfs uri =
                    writeRaw h = do
                     -- We honour original file line endings
                     hSetNewlineMode h noNewlineTranslation
+                    hSetEncoding h utf8
                     hPutStr h contents
                logs  $ "haskell-lsp:persistFileVFS: Writing virtual file: " 
                     ++ "uri = " ++ show uri ++ ", virtual file = " ++ show tfn


### PR DESCRIPTION
* In windows `hPutStr` uses by default,  the default system encoding to write content
  * In windows almost never is utf8 (in unix and macos is) 
* This make that utf8 original content are being writed incorrectly in the vfs temp file
* AFAIK all haskell-lsp clients are assuming that contents *must* be in utf8
  * f.e. hlint do it
  * if it is no the case we should save, or guess(?), the original file encoding
    * or convert the original encoding to utf8 in clients
* It hopefully closes https://github.com/haskell/haskell-ide-engine/issues/1560
