### PR TITLE
Add diagnostic and completion tags

### DIFF
--- a/haskell-lsp-types/src/Language/Haskell/LSP/Types/Capabilities.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/Types/Capabilities.hs
@@ -103,7 +103,7 @@ capsForVersion (LSPVersion maj min) = ClientCapabilities (Just w) (Just td) Noth
           (Just (DocumentLinkClientCapabilities dynamicReg))
           (since 3 6 (ColorProviderClientCapabilities dynamicReg))
           (Just (RenameClientCapabilities dynamicReg (since 3 12 True)))
-          (Just (PublishDiagnosticsClientCapabilities (since 3 7 True)))
+          (Just publishDiagnosticsCapabilities)
           (since 3 10 foldingRangeCapability)
     sync =
       SynchronizationTextDocumentClientCapabilities
@@ -125,9 +125,13 @@ capsForVersion (LSPVersion maj min) = ClientCapabilities (Just w) (Just td) Noth
       (since 3 3 (List [MkPlainText, MkMarkdown]))
       (Just True)
       (since 3 9 True)
+      (since 3 15 completionItemTagsCapabilities)
 
     completionItemKindCapabilities =
       CompletionItemKindClientCapabilities (Just ciKs)
+
+    completionItemTagsCapabilities =
+      CompletionItemTagsClientCapabilities (List [ CtDeprecated ])
 
     ciKs
       | maj >= 3 && min >= 4 = List (oldCiKs ++ newCiKs)
@@ -205,6 +209,15 @@ capsForVersion (LSPVersion maj min) = ClientCapabilities (Just w) (Just td) Noth
         dynamicReg
         Nothing
         (Just False)
+
+    publishDiagnosticsCapabilities =
+      PublishDiagnosticsClientCapabilities
+        (since 3 7 True)
+        (since 3 15 publishDiagnosticsTagsCapabilities)
+
+    publishDiagnosticsTagsCapabilities =
+      PublishDiagnosticsTagsClientCapabilities
+        (List [ DtUnnecessary, DtDeprecated ])
 
     dynamicReg
       | maj >= 3  = Just True

--- a/haskell-lsp-types/src/Language/Haskell/LSP/Types/ClientCapabilities.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/Types/ClientCapabilities.hs
@@ -644,7 +644,6 @@ data CompletionItemTagsClientCapabilities =
       _valueSet :: List CompletionItemTag
     } deriving (Show, Read, Eq)
 
-
 $(deriveJSON lspOptions ''CompletionItemTagsClientCapabilities)
 
 data CompletionItemClientCapabilities =
@@ -931,7 +930,6 @@ data PublishDiagnosticsTagsClientCapabilities =
     { -- | The tags supported by the client.
       _valueSet :: List DiagnosticTag
     } deriving (Show, Read, Eq)
-
 
 $(deriveJSON lspOptions ''PublishDiagnosticsTagsClientCapabilities)
 

--- a/haskell-lsp-types/src/Language/Haskell/LSP/Types/ClientCapabilities.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/Types/ClientCapabilities.hs
@@ -9,6 +9,7 @@ import Data.Default
 import Language.Haskell.LSP.Types.Constants
 import Language.Haskell.LSP.Types.CodeAction
 import Language.Haskell.LSP.Types.Completion
+import Language.Haskell.LSP.Types.Diagnostic
 import Language.Haskell.LSP.Types.List
 import Language.Haskell.LSP.Types.MarkupContent
 import Language.Haskell.LSP.Types.Symbol
@@ -637,6 +638,15 @@ instance Default SynchronizationTextDocumentClientCapabilities where
 
 -- -------------------------------------
 
+data CompletionItemTagsClientCapabilities =
+  CompletionItemTagsClientCapabilities
+    { -- | The tag supported by the client.
+      _valueSet :: List CompletionItemTag
+    } deriving (Show, Read, Eq)
+
+
+$(deriveJSON lspOptions ''CompletionItemTagsClientCapabilities)
+
 data CompletionItemClientCapabilities =
   CompletionItemClientCapabilities
     { -- | Client supports snippets as insert text.
@@ -659,6 +669,12 @@ data CompletionItemClientCapabilities =
 
       -- | Client supports the preselect property on a completion item.
     , _preselectSupport :: Maybe Bool
+
+      -- | Client supports the tag property on a completion item. Clients
+      -- supporting tags have to handle unknown tags gracefully. Clients
+      -- especially need to preserve unknown tags when sending a
+      -- completion item back to the server in a resolve call.
+    , _tagSupport :: Maybe CompletionItemTagsClientCapabilities
     } deriving (Show, Read, Eq)
 
 $(deriveJSON lspOptions ''CompletionItemClientCapabilities)
@@ -910,10 +926,24 @@ $(deriveJSON lspOptions ''RenameClientCapabilities)
 
 -- -------------------------------------
 
+data PublishDiagnosticsTagsClientCapabilities =
+  PublishDiagnosticsTagsClientCapabilities
+    { -- | The tags supported by the client.
+      _valueSet :: List DiagnosticTag
+    } deriving (Show, Read, Eq)
+
+
+$(deriveJSON lspOptions ''PublishDiagnosticsTagsClientCapabilities)
+
 data PublishDiagnosticsClientCapabilities =
   PublishDiagnosticsClientCapabilities
     { -- | Whether the clients accepts diagnostics with related information.
       _relatedInformation :: Maybe Bool
+      -- | Client supports the tag property to provide metadata about a
+      -- diagnostic.
+      --
+      -- Clients supporting tags have to handle unknown tags gracefully.
+    , _tagSupport :: Maybe PublishDiagnosticsTagsClientCapabilities
     } deriving (Show, Read, Eq)
 
 $(deriveJSON lspOptions ''PublishDiagnosticsClientCapabilities)

--- a/haskell-lsp-types/src/Language/Haskell/LSP/Types/Completion.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/Types/Completion.hs
@@ -102,6 +102,17 @@ instance A.FromJSON CompletionItemKind where
   parseJSON (A.Number 25) = pure CiTypeParameter
   parseJSON _             = mempty
 
+data CompletionItemTag
+  -- | Render a completion as obsolete, usually using a strike-out.
+  = CtDeprecated
+  deriving (Eq, Ord, Show, Read)
+
+instance A.ToJSON CompletionItemTag where
+  toJSON CtDeprecated  = A.Number 1
+
+instance A.FromJSON CompletionItemTag where
+  parseJSON (A.Number 1) = pure CtDeprecated
+  parseJSON _            = mempty
 
 -- ---------------------------------------------------------------------
 {-
@@ -193,6 +204,10 @@ interface CompletionItem {
      * an icon is chosen by the editor.
      */
     kind?: number;
+    /**
+     * Tags for this completion item.
+     */
+    tags?: CompletionItemTag[];
     /**
      * A human-readable string with additional information
      * about this item, like type or symbol information.
@@ -326,6 +341,7 @@ data CompletionItem =
                        -- the text that is inserted when selecting this
                        -- completion.
     , _kind                :: Maybe CompletionItemKind
+    , _tags                :: List CompletionItemTag -- ^ Tags for this completion item.
     , _detail              :: Maybe Text -- ^ A human-readable string with additional
                               -- information about this item, like type or
                               -- symbol information.

--- a/haskell-lsp-types/src/Language/Haskell/LSP/Types/Diagnostic.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/Types/Diagnostic.hs
@@ -59,6 +59,49 @@ instance A.FromJSON DiagnosticSeverity where
   parseJSON (A.Number 4) = pure DsHint
   parseJSON _            = mempty
 
+{-
+The diagnostic tags.
+
+export namespace DiagnosticTag {
+    /**
+     * Unused or unnecessary code.
+     *
+     * Clients are allowed to render diagnostics with this tag faded out instead of having
+     * an error squiggle.
+     */
+    export const Unnecessary: 1;
+    /**
+     * Deprecated or obsolete code.
+     *
+     * Clients are allowed to rendered diagnostics with this tag strike through.
+     */
+    export const Deprecated: 2;
+}
+-}
+data DiagnosticTag
+  -- | Unused or unnecessary code.
+  --
+  -- Clients are allowed to render diagnostics with this tag faded out
+  -- instead of having an error squiggle.
+  = DtUnnecessary
+  -- | Deprecated or obsolete code.
+  --
+  -- Clients are allowed to rendered diagnostics with this tag strike
+  -- through.
+  | DtDeprecated
+  deriving (Eq, Ord, Show, Read, Generic)
+
+instance NFData DiagnosticTag
+
+instance A.ToJSON DiagnosticTag where
+  toJSON DtUnnecessary = A.Number 1
+  toJSON DtDeprecated  = A.Number 2
+
+instance A.FromJSON DiagnosticTag where
+  parseJSON (A.Number 1) = pure DtUnnecessary
+  parseJSON (A.Number 2) = pure DtDeprecated
+  parseJSON _            = mempty
+
 -- ---------------------------------------------------------------------
 {-
 Represents a related message and source code location for a diagnostic. This should be
@@ -126,6 +169,13 @@ interface Diagnostic {
     message: string;
 
     /**
+     * Additional metadata about the diagnostic.
+     *
+     * @since 3.15.0
+     */
+    tags?: DiagnosticTag[];
+
+    /**
      * An array of related diagnostic information, e.g. when symbol-names within
      * a scope collide all definitions can be marked via this property.
      */
@@ -150,6 +200,7 @@ data Diagnostic =
     , _code               :: Maybe NumberOrString
     , _source             :: Maybe DiagnosticSource
     , _message            :: Text
+    , _tags               :: Maybe (List DiagnosticTag)
     , _relatedInformation :: Maybe (List DiagnosticRelatedInformation)
     } deriving (Show, Read, Eq, Ord, Generic)
 

--- a/haskell-lsp-types/src/Language/Haskell/LSP/Types/Lens.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/Types/Lens.hs
@@ -32,6 +32,7 @@ makeFieldsNoPrefix ''SymbolClientCapabilities
 makeFieldsNoPrefix ''ExecuteClientCapabilities
 makeFieldsNoPrefix ''WorkspaceClientCapabilities
 makeFieldsNoPrefix ''SynchronizationTextDocumentClientCapabilities
+makeFieldsNoPrefix ''CompletionItemTagsClientCapabilities
 makeFieldsNoPrefix ''CompletionItemClientCapabilities
 makeFieldsNoPrefix ''CompletionItemKindClientCapabilities
 makeFieldsNoPrefix ''CompletionClientCapabilities
@@ -56,6 +57,7 @@ makeFieldsNoPrefix ''DocumentLinkClientCapabilities
 makeFieldsNoPrefix ''ColorProviderClientCapabilities
 makeFieldsNoPrefix ''RenameClientCapabilities
 makeFieldsNoPrefix ''PublishDiagnosticsClientCapabilities
+makeFieldsNoPrefix ''PublishDiagnosticsTagsClientCapabilities
 makeFieldsNoPrefix ''TextDocumentClientCapabilities
 makeFieldsNoPrefix ''ClientCapabilities
 

--- a/test/DiagnosticsSpec.hs
+++ b/test/DiagnosticsSpec.hs
@@ -35,14 +35,14 @@ mkDiagnostic ms str =
     rng = J.Range (J.Position 0 1) (J.Position 3 0)
     loc = J.Location (J.Uri "file") rng
   in
-    J.Diagnostic rng Nothing Nothing ms str (Just (J.List [J.DiagnosticRelatedInformation loc str]))
+    J.Diagnostic rng Nothing Nothing ms str Nothing (Just (J.List [J.DiagnosticRelatedInformation loc str]))
 
 mkDiagnostic2 :: Maybe J.DiagnosticSource -> Text -> J.Diagnostic
 mkDiagnostic2 ms str =
   let
     rng = J.Range (J.Position 4 1) (J.Position 5 0)
     loc = J.Location (J.Uri "file") rng
-  in J.Diagnostic rng Nothing Nothing ms str (Just (J.List [J.DiagnosticRelatedInformation loc str]))
+  in J.Diagnostic rng Nothing Nothing ms str Nothing (Just (J.List [J.DiagnosticRelatedInformation loc str]))
 
 -- ---------------------------------------------------------------------
 


### PR DESCRIPTION
These appear in the [3.15 spec][spec], and provide a way to provide additional metadata about diagnostics and completion items. For instance, the "Unnecessary" tag says this diagnostic warns about unused code or definitions.

### Example
Just demonstrating the "unused" tag being rendered by VS Code.
![image](https://user-images.githubusercontent.com/4346137/74931171-fbc01e00-53d6-11ea-8c62-3966400486a4.png)


[spec]: https://microsoft.github.io/language-server-protocol/specifications/specification-3-15/