### PR TITLE
Add NormalizedFilePath from ghcide

### DIFF
--- a/haskell-lsp-types/haskell-lsp-types.cabal
+++ b/haskell-lsp-types/haskell-lsp-types.cabal
@@ -48,6 +48,7 @@ library
   -- ghc-options:         -Werror
   build-depends:       base >= 4.9 && < 4.14
                      , aeson >=1.2.2.0
+                     , binary
                      , bytestring
                      , data-default
                      , deepseq

--- a/haskell-lsp-types/src/Language/Haskell/LSP/Types/Uri.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/Types/Uri.hs
@@ -140,28 +140,28 @@ platformAdjustToUriPath systemOS srcPath
 --
 -- This is one of the most performance critical parts of ghcide, do not
 -- modify it without profiling.
-data NormalizedFilePath = NormalizedFilePath NormalizedUri !Int !FilePath
+data NormalizedFilePath = NormalizedFilePath NormalizedUri !FilePath
     deriving (Generic, Eq, Ord)
 
 instance NFData NormalizedFilePath
 
 instance Binary NormalizedFilePath where
-  put (NormalizedFilePath _ _ fp) = put fp
+  put (NormalizedFilePath _ fp) = put fp
   get = do
     v <- Data.Binary.get :: Get FilePath
     return (toNormalizedFilePath v)
 
 instance Show NormalizedFilePath where
-  show (NormalizedFilePath _ _ fp) = "NormalizedFilePath " ++ show fp
+  show (NormalizedFilePath _ fp) = "NormalizedFilePath " ++ show fp
 
 instance Hashable NormalizedFilePath where
-  hash (NormalizedFilePath _ h _) = h
+  hash (NormalizedFilePath uri _) = hash uri
 
 instance IsString NormalizedFilePath where
     fromString = toNormalizedFilePath
 
 toNormalizedFilePath :: FilePath -> NormalizedFilePath
-toNormalizedFilePath fp = NormalizedFilePath nuri (hash nfp) nfp
+toNormalizedFilePath fp = NormalizedFilePath nuri nfp
   where nfp | fp == "" = "" 
             -- ghcide want to keep empty paths instead of normalising them to "."
             | otherwise = FP.normalise fp
@@ -170,13 +170,13 @@ toNormalizedFilePath fp = NormalizedFilePath nuri (hash nfp) nfp
         nuri = NormalizedUri (hash nuriStr) nuriStr
 
 fromNormalizedFilePath :: NormalizedFilePath -> FilePath
-fromNormalizedFilePath (NormalizedFilePath _ _ fp) = fp
+fromNormalizedFilePath (NormalizedFilePath _ fp) = fp
 
 normalizedFilePathToUri :: NormalizedFilePath -> NormalizedUri
-normalizedFilePathToUri (NormalizedFilePath uri _ _) = uri
+normalizedFilePathToUri (NormalizedFilePath uri _) = uri
 
 uriToNormalizedFilePath :: NormalizedUri -> Maybe NormalizedFilePath
 uriToNormalizedFilePath nuri = fmap toNormFP mbFilePath
   where mbFilePath = platformAwareUriToFilePath System.Info.os (fromNormalizedUri nuri) 
         -- This file path is already normalized by construction
-        toNormFP nfp = NormalizedFilePath nuri (hash nfp) nfp
+        toNormFP nfp = NormalizedFilePath nuri nfp

--- a/haskell-lsp-types/src/Language/Haskell/LSP/Types/Uri.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/Types/Uri.hs
@@ -57,8 +57,8 @@ instance Hashable NormalizedUri where
 
 instance NFData NormalizedUri
 
-isUnescapedInFilePath :: SystemOS -> Char -> Bool
-isUnescapedInFilePath systemOS c
+isUnescapedInUriPath :: SystemOS -> Char -> Bool
+isUnescapedInUriPath systemOS c
    | systemOS == windowsOS = isUnreserved c || c `elem` [':', '\\', '/']
    | otherwise = isUnreserved c || c == '/'
 
@@ -143,7 +143,7 @@ platformAdjustToUriPath systemOS srcPath
         case splitDrive srcPath of
             (drv, rest) ->
                 convertDrive drv `FPP.joinDrive`
-                FPP.joinPath (map (escapeURIString (isUnescapedInFilePath systemOS)) $ splitDirectories rest)
+                FPP.joinPath (map (escapeURIString (isUnescapedInUriPath systemOS)) $ splitDirectories rest)
     -- splitDirectories does not remove the path separator after the drive so
     -- we do a final replacement of \ to /
     convertDrive drv
@@ -182,7 +182,7 @@ toNormalizedFilePath fp = NormalizedFilePath nuri nfp
   where nfp | fp == "" = "" 
             -- ghcide want to keep empty paths instead of normalising them to "."
             | otherwise = FP.normalise fp
-        uriPath = normalizeUriEscaping (platformAdjustToUriPath System.Info.os nfp)
+        uriPath = platformAdjustToUriPath System.Info.os nfp
         nuriStr = T.pack $ fileScheme <> "//" <> uriPath
         nuri = NormalizedUri (hash nuriStr) nuriStr
 

--- a/haskell-lsp-types/src/Language/Haskell/LSP/Types/Uri.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/Types/Uri.hs
@@ -181,4 +181,4 @@ uriToNormalizedFilePath :: NormalizedUri -> Maybe NormalizedFilePath
 uriToNormalizedFilePath nuri = fmap toNormFP mbFilePath
   where mbFilePath = platformAwareUriToFilePath System.Info.os (fromNormalizedUri nuri) 
         -- This file path is already normalized by construction
-        toNormFP nfp = NormalizedFilePath nuri nfp
+        toNormFP = NormalizedFilePath nuri

--- a/haskell-lsp-types/src/Language/Haskell/LSP/Types/Uri.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/Types/Uri.hs
@@ -178,7 +178,5 @@ normalizedFilePathToUri :: NormalizedFilePath -> NormalizedUri
 normalizedFilePathToUri (NormalizedFilePath uri _) = uri
 
 uriToNormalizedFilePath :: NormalizedUri -> Maybe NormalizedFilePath
-uriToNormalizedFilePath nuri = fmap toNormFP mbFilePath
-  where mbFilePath = platformAwareUriToFilePath System.Info.os (fromNormalizedUri nuri) 
-        -- This file path is already normalized by construction
-        toNormFP = NormalizedFilePath nuri
+uriToNormalizedFilePath nuri = fmap (NormalizedFilePath nuri) mbFilePath
+  where mbFilePath = platformAwareUriToFilePath System.Info.os (fromNormalizedUri nuri)

--- a/haskell-lsp-types/src/Language/Haskell/LSP/Types/Uri.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/Types/Uri.hs
@@ -182,8 +182,8 @@ toNormalizedFilePath fp = NormalizedFilePath nuri nfp
   where nfp | fp == "" = "" 
             -- ghcide want to keep empty paths instead of normalising them to "."
             | otherwise = FP.normalise fp
-        uriStr = fileScheme <> "//" <> platformAdjustToUriPath System.Info.os nfp
-        nuriStr = T.pack (normalizeUriEscaping uriStr)
+        uriPath = normalizeUriEscaping (platformAdjustToUriPath System.Info.os nfp)
+        nuriStr = T.pack $ fileScheme <> "//" <> uriPath
         nuri = NormalizedUri (hash nuriStr) nuriStr
 
 fromNormalizedFilePath :: NormalizedFilePath -> FilePath

--- a/haskell-lsp-types/src/Language/Haskell/LSP/Types/Uri.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/Types/Uri.hs
@@ -70,6 +70,7 @@ windowsOS = "mingw32"
 
 type SystemOS = String
 
+{-# DEPRECATED uriToFilePath "Use uriToNormalizedFilePath" #-}
 uriToFilePath :: Uri -> Maybe FilePath
 uriToFilePath = platformAwareUriToFilePath System.Info.os
 
@@ -97,6 +98,7 @@ platformAdjustFromUriPath systemOS authority srcPath =
               else firstSegment
       in FPW.joinDrive drive $ FPW.joinPath rest
 
+{-# DEPRECATED filePathToUri "Use normalizedFilePathToUri" #-}
 filePathToUri :: FilePath -> Uri
 filePathToUri = (platformAwareFilePathToUri System.Info.os) . FP.normalise
 

--- a/haskell-lsp-types/src/Language/Haskell/LSP/Types/Uri.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/Types/Uri.hs
@@ -68,7 +68,7 @@ isUnescapedInUriPath systemOS c
 normalizeUriEscaping :: String -> String
 normalizeUriEscaping uri = escapeURIString isUnescaped unEscapedUri
   where unEscapedUri = unEscapeString uri
-        isUnescaped | fileScheme `isPrefixOf` unEscapedUri = isUnescapedInFilePath System.Info.os
+        isUnescaped | fileScheme `isPrefixOf` unEscapedUri = isUnescapedInUriPath System.Info.os
                     | otherwise = isUnescapedInURI
 
 toNormalizedUri :: Uri -> NormalizedUri

--- a/haskell-lsp-types/src/Language/Haskell/LSP/Types/Uri.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/Types/Uri.hs
@@ -14,6 +14,9 @@ module Language.Haskell.LSP.Types.Uri
   , fromNormalizedFilePath
   , normalizedFilePathToUri
   , uriToNormalizedFilePath
+  -- Private functions
+  , platformAwareUriToFilePath
+  , platformAwareFilePathToUri
   )
   where
 
@@ -74,10 +77,10 @@ windowsOS = "mingw32"
 
 type SystemOS = String
 
-{-# DEPRECATED uriToFilePath "Use uriToNormalizedFilePath" #-}
 uriToFilePath :: Uri -> Maybe FilePath
 uriToFilePath = platformAwareUriToFilePath System.Info.os
 
+{-# WARNING platformAwareUriToFilePath "This function is considered private. Use normalizedFilePathToUri instead." #-}
 platformAwareUriToFilePath :: String -> Uri -> Maybe FilePath
 platformAwareUriToFilePath systemOS (Uri uri) = do
   URI{..} <- parseURI $ T.unpack uri
@@ -102,10 +105,10 @@ platformAdjustFromUriPath systemOS authority srcPath =
               else firstSegment
       in FPW.joinDrive drive $ FPW.joinPath rest
 
-{-# DEPRECATED filePathToUri "Use normalizedFilePathToUri" #-}
 filePathToUri :: FilePath -> Uri
 filePathToUri = (platformAwareFilePathToUri System.Info.os) . FP.normalise
 
+{-# WARNING platformAwareFilePathToUri "This function is considered private. Use normalizedUriToFilePath instead." #-}
 platformAwareFilePathToUri :: SystemOS -> FilePath -> Uri
 platformAwareFilePathToUri systemOS fp = Uri . T.pack . show $ URI
   { uriScheme = fileScheme

--- a/haskell-lsp-types/src/Language/Haskell/LSP/Types/Uri.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/Types/Uri.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -20,6 +21,9 @@ import           Control.DeepSeq
 import qualified Data.Aeson                                 as A
 import           Data.Binary                                (Binary, Get, put, get)
 import           Data.Hashable
+#if __GLASGOW_HASKELL__ < 804
+import           Data.Monoid                                ((<>))
+#endif
 import           Data.String                                (IsString, fromString)
 import           Data.Text                                  (Text)
 import qualified Data.Text                                  as T

--- a/haskell-lsp-types/src/Language/Haskell/LSP/Types/Uri.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/Types/Uri.hs
@@ -180,9 +180,7 @@ instance IsString NormalizedFilePath where
 
 toNormalizedFilePath :: FilePath -> NormalizedFilePath
 toNormalizedFilePath fp = NormalizedFilePath nuri nfp
-  where nfp | fp == "" = "" 
-            -- ghcide want to keep empty paths instead of normalising them to "."
-            | otherwise = FP.normalise fp
+  where nfp = FP.normalise fp
         uriPath = platformAdjustToUriPath System.Info.os nfp
         nuriStr = T.pack $ fileScheme <> "//" <> uriPath
         nuri = NormalizedUri (hash nuriStr) nuriStr

--- a/test/URIFilePathSpec.hs
+++ b/test/URIFilePathSpec.hs
@@ -204,6 +204,12 @@ uriNormalizeSpec = do
     toNormalizedUri (Uri $ pack $ escapeURIString isUnescapedInURI uri) `shouldBe`
         toNormalizedUri (Uri $ pack $ escapeURIString (const False) uri)
 
+  it "ignores differences in percent-encoding (examples)" $ do
+    toNormalizedUri (Uri $ pack "http://server/path%C3%B1?param=%C3%B1") `shouldBe`
+        toNormalizedUri (Uri $ pack "http://server/path%c3%b1?param=%c3%b1")
+    toNormalizedUri (Uri $ pack "file:///path%2A") `shouldBe`
+        toNormalizedUri (Uri $ pack "file:///path%2a")
+
   it "normalizes uri file path when converting from uri to normalized uri" $ do
     let (NormalizedUri _ uri) = toNormalizedUri noNormalizedUri
     let (Uri nuri) = testUri

--- a/test/URIFilePathSpec.hs
+++ b/test/URIFilePathSpec.hs
@@ -157,3 +157,19 @@ arbitraryUnicodeChar =
   where
     isSurrogate c = generalCategory c == Surrogate
 #endif
+
+normalizedFilePathSpec :: Spec
+normalizedFilePathSpec = do
+  it "makes file path normalized" $ property $ forAll genFilePath $ \fp -> do
+    let nfp = toNormalizedFilePath fp
+    fromNormalizedFilePath nfp `shouldBe` (normalise fp)
+
+  it "converts to a normalized uri and back" $ property $ forAll genFilePath $ \fp -> do
+    let nuri = normalizedFilePathToUri (toNormalizedFilePath fp)
+    let (Just nfp) = uriToNormalizedFilePath nuri
+    fromNormalizedFilePath nfp `shouldBe` (normalise fp)
+
+  it "creates the same NormalizedUri than the older implementation" $ property $ forAll genFilePath $ \fp -> do
+    let nuri = normalizedFilePathToUri (toNormalizedFilePath fp)
+    let oldNuri = toNormalizedUri (filePathToUri fp)
+    nuri `shouldBe` oldNuri

--- a/test/URIFilePathSpec.hs
+++ b/test/URIFilePathSpec.hs
@@ -128,6 +128,12 @@ uriNormalizeSpec = do
     let (Uri nuri) = testUri
     uri `shouldBe` nuri
 
+  it "converts a file path to a normalized URI and back" $ property $ forAll genFilePath $ \fp -> do
+    let nuri = toNormalizedUri (filePathToUri fp)
+    case uriToFilePath (fromNormalizedUri nuri) of
+      Just nfp -> nfp `shouldBe` (normalise fp)
+      Nothing -> return () -- Some unicode paths creates invalid uris, ignoring for now
+
 genFilePath :: Gen FilePath
 genFilePath | isWindows = genWindowsFilePath
             | otherwise = genPosixFilePath
@@ -166,8 +172,9 @@ normalizedFilePathSpec = do
 
   it "converts to a normalized uri and back" $ property $ forAll genFilePath $ \fp -> do
     let nuri = normalizedFilePathToUri (toNormalizedFilePath fp)
-    let (Just nfp) = uriToNormalizedFilePath nuri
-    fromNormalizedFilePath nfp `shouldBe` (normalise fp)
+    case uriToNormalizedFilePath nuri of
+      Just nfp -> fromNormalizedFilePath nfp `shouldBe` (normalise fp)
+      Nothing -> return () -- Some unicode paths creates invalid uris, ignoring for now
 
   it "creates the same NormalizedUri than the older implementation" $ property $ forAll genFilePath $ \fp -> do
     let nuri = normalizedFilePathToUri (toNormalizedFilePath fp)

--- a/test/URIFilePathSpec.hs
+++ b/test/URIFilePathSpec.hs
@@ -2,21 +2,22 @@
 {-# LANGUAGE OverloadedStrings #-}
 module URIFilePathSpec where
 
-import Control.Monad (when)
+import Control.Monad                          (when)
 import Data.List
 #if __GLASGOW_HASKELL__ < 808
-import Data.Monoid ((<>))
+import Data.Monoid                            ((<>))
 #endif
 import Data.Text                              (Text, pack)
 import Language.Haskell.LSP.Types
 
-import           Network.URI
+import Network.URI
 import Test.Hspec
 import Test.QuickCheck
 #if !MIN_VERSION_QuickCheck(2,10,0)
 import Data.Char                              (GeneralCategory(..), generalCategory)
 #endif
-import System.FilePath (normalise)
+import qualified System.FilePath.Windows as FPW
+import System.FilePath                        (normalise)
 import qualified System.Info
 -- ---------------------------------------------------------------------
 
@@ -28,9 +29,88 @@ main = hspec spec
 
 spec :: Spec
 spec = do
+  describe "Platform aware URI file path functions" platformAwareUriFilePathSpec
   describe "URI file path functions" uriFilePathSpec
   describe "URI normalization functions" uriNormalizeSpec
   describe "Normalized file path functions" normalizedFilePathSpec
+
+windowsOS :: String
+windowsOS = "mingw32"
+
+testPosixUri :: Uri
+testPosixUri = Uri $ pack "file:///home/myself/example.hs"
+
+testPosixFilePath :: FilePath
+testPosixFilePath = "/home/myself/example.hs"
+
+relativePosixFilePath :: FilePath
+relativePosixFilePath = "myself/example.hs"
+
+testWindowsUri :: Uri
+testWindowsUri = Uri $ pack "file:///c:/Users/myself/example.hs"
+
+testWindowsFilePath :: FilePath
+testWindowsFilePath = "c:\\Users\\myself\\example.hs"
+
+platformAwareUriFilePathSpec :: Spec
+platformAwareUriFilePathSpec = do
+  it "converts a URI to a POSIX file path" $ do
+    let theFilePath = platformAwareUriToFilePath "posix" testPosixUri
+    theFilePath `shouldBe` Just testPosixFilePath
+
+  it "converts a POSIX file path to a URI" $ do
+    let theUri = platformAwareFilePathToUri "posix" testPosixFilePath
+    theUri `shouldBe` testPosixUri
+
+  it "converts a URI to a Windows file path" $ do
+    let theFilePath = platformAwareUriToFilePath windowsOS testWindowsUri
+    theFilePath `shouldBe` Just testWindowsFilePath
+
+  it "converts a Windows file path to a URI" $ do
+    let theUri = platformAwareFilePathToUri windowsOS testWindowsFilePath
+    theUri `shouldBe` testWindowsUri
+
+  it "converts a POSIX file path to a URI" $ do
+    let theFilePath = platformAwareFilePathToUri "posix" "./Functional.hs"
+    theFilePath `shouldBe` (Uri "file://./Functional.hs")
+
+  it "converts a Windows file path to a URI" $ do
+    let theFilePath = platformAwareFilePathToUri windowsOS "./Functional.hs"
+    theFilePath `shouldBe` (Uri "file:///./Functional.hs")
+
+  it "converts a Windows file path to a URI" $ do
+    let theFilePath = platformAwareFilePathToUri windowsOS "c:/Functional.hs"
+    theFilePath `shouldBe` (Uri "file:///c:/Functional.hs")
+
+  it "converts a POSIX file path to a URI and back" $ do
+    let theFilePath = platformAwareFilePathToUri "posix" "./Functional.hs"
+    theFilePath `shouldBe` (Uri "file://./Functional.hs")
+    let Just (URI scheme' auth' path' query' frag') =  parseURI "file://./Functional.hs"
+    (scheme',auth',path',query',frag') `shouldBe`
+      ("file:"
+      ,Just (URIAuth {uriUserInfo = "", uriRegName = ".", uriPort = ""}) -- AZ: Seems odd
+      ,"/Functional.hs"
+      ,""
+      ,"")
+    Just "./Functional.hs" `shouldBe` platformAwareUriToFilePath "posix" theFilePath
+
+  it "converts a Posix file path to a URI and back" $ property $ forAll genPosixFilePath $ \fp -> do
+      let uri = platformAwareFilePathToUri "posix" fp
+      platformAwareUriToFilePath "posix" uri `shouldBe` Just fp
+
+  it "converts a Windows file path to a URI and back" $ property $ forAll genWindowsFilePath $ \fp -> do
+      let uri = platformAwareFilePathToUri windowsOS fp
+      -- We normalise to account for changes in the path separator.
+      -- But driver letters are *not* normalized so we skip them
+      when (not $ "c:" `isPrefixOf` fp) $
+        platformAwareUriToFilePath windowsOS uri `shouldBe` Just (FPW.normalise fp)
+
+  it "converts a relative POSIX file path to a URI and back" $ do
+    let uri = platformAwareFilePathToUri "posix" relativePosixFilePath
+    uri `shouldBe` Uri "file://myself/example.hs"
+    let back = platformAwareUriToFilePath "posix" uri
+    back `shouldBe` Just relativePosixFilePath
+
 
 testUri :: Uri
 testUri | isWindows = Uri "file:///C:/Users/myself/example.hs"

--- a/test/URIFilePathSpec.hs
+++ b/test/URIFilePathSpec.hs
@@ -215,6 +215,12 @@ uriNormalizeSpec = do
     let nuri = toNormalizedUri (filePathToUri fp)
     uriToFilePath (fromNormalizedUri nuri) `shouldBe` Just fp
 
+  it "converts a file path with substrings that looks like uri escaped chars and back" $ do
+    let start = if isWindows then "C:\\" else "/"
+    let fp = start ++ "ca%C3%B1a"
+    let nuri = toNormalizedUri (filePathToUri fp)
+    uriToFilePath (fromNormalizedUri nuri) `shouldBe` Just fp
+
   it "converts a file path to a normalized URI and back" $ property $ forAll genFilePath $ \fp -> do
     let nuri = toNormalizedUri (filePathToUri fp)
     case uriToFilePath (fromNormalizedUri nuri) of
@@ -266,6 +272,12 @@ normalizedFilePathSpec = do
   it "converts a file path with reserved uri chars to a normalized URI and back" $ do
     let start = if isWindows then "C:\\" else "/"
     let fp = start ++ "path;part#fragmen?param=val"
+    let nuri = normalizedFilePathToUri (toNormalizedFilePath fp)
+    fmap fromNormalizedFilePath (uriToNormalizedFilePath nuri) `shouldBe` Just fp
+
+  it "converts a file path with substrings that looks like uri escaped chars and back" $ do
+    let start = if isWindows then "C:\\" else "/"
+    let fp = start ++ "ca%C3%B1a"
     let nuri = normalizedFilePathToUri (toNormalizedFilePath fp)
     fmap fromNormalizedFilePath (uriToNormalizedFilePath nuri) `shouldBe` Just fp
 


### PR DESCRIPTION
* To track in types we have a normalized path and it is sure to conver to normalized uri without an extra normalization step
* Fixes #212 and let ghcide not worry about its specofoc implementation
* The implementation only calls `FP.normalise` once in `fromNormalizedFilePath . uriToNormalizedFilePath . normalizedFilePathToUri . toNormalizedFilePath`, like the actual ghcide impl so i hope the performance will be not degraded
  * it would be useful to have a benchmark over it though
* Significant changes:
  * *platform\* functions are not public any more* cause they are a implementation detail that should not be exposed
  * *the hash of NormalizedFilePath is equal now to the hash of NormalizedUri*: imo they *must* match for all cases and we avoid an additional hash call (/cc @cocreature)
  * *tests dont check both os's anymore* so the actual ci will not tests windows uris. I want to add windows ci soon so the tests will be recoved
    * The test suit passes locally in my windows systems
  * `uriTofilePath` and `filePathToUri` are now deprecated, with the goal of replace them with the new `NormalizedFilePath` functions. They should be removed in the next breaking release after this one.
* Caveats: [i've kept the ghcide corner case for empty file paths](https://github.com/alanz/haskell-lsp/pull/224/files#diff-c671434724ea00cc2090da17fd103d7dR167) but i think it would be nice to not include it in the library. Not sure if it is possible without significant changes in the lib or ghcide code