### PR TITLE
Change ResponseMessage result to be `Either ResponseError a`

### DIFF
--- a/haskell-lsp-types/haskell-lsp-types.cabal
+++ b/haskell-lsp-types/haskell-lsp-types.cabal
@@ -58,7 +58,6 @@ library
                      , scientific
                      , text
                      , unordered-containers
-                     , either >= 5.0.1.1
   hs-source-dirs:      src
   default-language:    Haskell2010
 

--- a/haskell-lsp-types/haskell-lsp-types.cabal
+++ b/haskell-lsp-types/haskell-lsp-types.cabal
@@ -58,6 +58,7 @@ library
                      , scientific
                      , text
                      , unordered-containers
+                     , either >= 5.0.1.1
   hs-source-dirs:      src
   default-language:    Haskell2010
 

--- a/haskell-lsp-types/src/Language/Haskell/LSP/Types/Message.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/Types/Message.hs
@@ -424,13 +424,13 @@ deriveJSON lspOptions{ fieldLabelModifier = customModifier } ''ResponseError
 
 data ResponseMessage a =
   ResponseMessage
-    { _rmjsonrpc :: Text
-    , _rmid      :: LspIdRsp
-    , _rmresult  :: Either ResponseError a
+    { _jsonrpc :: Text
+    , _id      :: LspIdRsp
+    , _result  :: Either ResponseError a
     } deriving (Read,Show,Eq)
 
 instance ToJSON a => ToJSON (ResponseMessage a) where
-  toJSON (ResponseMessage { _rmjsonrpc = jsonrpc, _rmid = lspid, _rmresult = result })
+  toJSON (ResponseMessage { _jsonrpc = jsonrpc, _id = lspid, _result = result })
     = object
       [ "jsonrpc" .= jsonrpc
       , "id" .= lspid

--- a/haskell-lsp-types/src/Language/Haskell/LSP/Types/Message.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/Types/Message.hs
@@ -446,13 +446,13 @@ instance (FromJSON a, Show a) => FromJSON (ResponseMessage a) where
     -- It is important to use .:! so that "result = null" (without error) gets decoded as Just Null
     _result  <- o .:! "result"
     _error   <- o .:? "error"
-    return $ ResponseMessage _jsonrpc _id $ case (_error, _result) of
-      ((Just err), Nothing   ) -> Left err
-      (Nothing   , (Just res)) -> Right res
-      ((Just err), (Just res)) ->
-        fail $ "both error and result cannot be present: error="
-          ++ show (err) ++ ", result=" ++ show (res)
+    result   <- case (_error, _result) of
+      ((Just err), Nothing   ) -> pure $ Left err
+      (Nothing   , (Just res)) -> pure $ Right res
+      ((Just err), (Just res)) -> fail $ "both error and result cannot be present: error=" ++ show (err) 
+        ++ ", result=" ++ show (res)
       (Nothing, Nothing) -> fail "both error and result cannot be Nothing"
+    return $ ResponseMessage _jsonrpc _id $ result
 
 type ErrorResponse = ResponseMessage ()
 

--- a/haskell-lsp-types/src/Language/Haskell/LSP/Types/Message.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/Types/Message.hs
@@ -370,6 +370,28 @@ instance A.FromJSON ErrorCode where
 
 -- -------------------------------------
 
+{-
+  https://microsoft.github.io/language-server-protocol/specification#responseMessage
+
+  interface ResponseError {
+    /**
+    * A number indicating the error type that occurred.
+    */
+    code: number;
+
+    /**
+    * A string providing a short description of the error.
+    */
+    message: string;
+
+    /**
+    * A primitive or structured value that contains additional
+    * information about the error. Can be omitted.
+    */
+    data?: string | number | boolean | array | object | null;
+  }
+-}
+
 data ResponseError =
   ResponseError
     { _code    :: ErrorCode
@@ -402,6 +424,7 @@ deriveJSON lspOptions{ fieldLabelModifier = customModifier } ''ResponseError
     error?: ResponseError;
   }
 -}
+
 data ResponseMessage a =
   ResponseMessage
     { _rmjsonrpc :: Text
@@ -430,7 +453,7 @@ instance FromJSON a => FromJSON (ResponseMessage a) where
     _id      <- o .: "id"
     -- It is important to use .:! so that result = null gets decoded as Just Nothing
     _result  <- o .:! "result"
-    _error   <- o .:! "error"
+    _error   <- o .:? "error"
     let result = parseRespResult _error _result
     return $ ResponseMessage _jsonrpc _id result
 

--- a/test/JsonSpec.hs
+++ b/test/JsonSpec.hs
@@ -8,7 +8,7 @@ module JsonSpec where
 
 import           Language.Haskell.LSP.Types
 
-import           Data.Aeson
+import qualified Data.Aeson                    as J
 import           Test.Hspec
 import           Test.Hspec.QuickCheck
 import           Test.QuickCheck               hiding (Success)
@@ -35,13 +35,16 @@ jsonSpec = do
     prop "MarkedString"      (propertyJsonRoundtrip :: MarkedString -> Property)
     prop "MarkupContent"     (propertyJsonRoundtrip :: MarkupContent -> Property)
     prop "HoverContents"     (propertyJsonRoundtrip :: HoverContents -> Property)
+    prop "ResponseError"     (propertyJsonRoundtrip :: ResponseError -> Property)
+    -- todo make sure it generates Left(error)
     prop "ResponseMessage"   (propertyJsonRoundtrip :: ResponseMessage () -> Property)
+    prop "ResponseMessage"   (propertyJsonRoundtrip :: ResponseMessage J.Value  -> Property)
 
 
 -- ---------------------------------------------------------------------
 
-propertyJsonRoundtrip :: (Eq a, Show a, ToJSON a, FromJSON a) => a -> Property
-propertyJsonRoundtrip a = Success a === fromJSON (toJSON a)
+propertyJsonRoundtrip :: (Eq a, Show a, J.ToJSON a, J.FromJSON a) => a -> Property
+propertyJsonRoundtrip a = J.Success a === J.fromJSON (J.toJSON a)
 
 -- ---------------------------------------------------------------------
 
@@ -104,4 +107,6 @@ smallList = resize 3 . listOf
 instance (Arbitrary a) => Arbitrary (List a) where
   arbitrary = List <$> arbitrary
 
+instance Arbitrary J.Value where
+  arbitrary = oneof [J.String <$> arbitrary, J.Number <$> arbitrary, J.Bool <$> arbitrary, pure J.Null]
 -- ---------------------------------------------------------------------

--- a/test/JsonSpec.hs
+++ b/test/JsonSpec.hs
@@ -9,6 +9,7 @@ module JsonSpec where
 import           Language.Haskell.LSP.Types
 
 import qualified Data.Aeson                    as J
+import           Data.List(isPrefixOf)
 import           Test.Hspec
 import           Test.Hspec.QuickCheck
 import           Test.QuickCheck               hiding (Success)
@@ -52,11 +53,14 @@ responseMessageSpec = do
               (ResponseMessage "2.0" (IdRspInt 123) (Right J.Null))
   describe "invalid JSON" $ do
     it "throws if neither result nor error is present" $ do
-      print (J.decode "{\"jsonrpc\":\"2.0\",\"id\":1}" :: Maybe (ResponseMessage ())) `shouldThrow` anyException
+      (J.eitherDecode "{\"jsonrpc\":\"2.0\",\"id\":1}" :: Either String (ResponseMessage ())) 
+        `shouldBe` Left ("Error in $: both error and result cannot be Nothing") 
     it "throws if both result and error are present" $ do
-      print (J.decode 
+      (J.eitherDecode 
         "{\"jsonrpc\":\"2.0\",\"id\": 1,\"result\":1,\"error\":{\"code\":-32700,\"message\":\"\",\"data\":null}}" 
-        :: Maybe (ResponseMessage Int)) `shouldThrow` anyException
+        :: Either String (ResponseMessage Int)) 
+        `shouldSatisfy` 
+          (either (\err -> isPrefixOf "Error in $: both error and result cannot be present" err) (\_ -> False))
 
 -- ---------------------------------------------------------------------
 

--- a/test/JsonSpec.hs
+++ b/test/JsonSpec.hs
@@ -35,7 +35,7 @@ jsonSpec = do
     prop "MarkedString"      (propertyJsonRoundtrip :: MarkedString -> Property)
     prop "MarkupContent"     (propertyJsonRoundtrip :: MarkupContent -> Property)
     prop "HoverContents"     (propertyJsonRoundtrip :: HoverContents -> Property)
-    prop "ResponseMessage"   (propertyJsonRoundtrip :: ResponseMessage (Maybe ()) -> Property)
+    prop "ResponseMessage"   (propertyJsonRoundtrip :: ResponseMessage () -> Property)
 
 
 -- ---------------------------------------------------------------------
@@ -68,13 +68,11 @@ instance Arbitrary a => Arbitrary (ResponseMessage a) where
       [ ResponseMessage
           <$> arbitrary
           <*> arbitrary
-          <*> (Just <$> arbitrary)
-          <*> pure Nothing
+          <*> (Right <$> arbitrary)
       , ResponseMessage
           <$> arbitrary
           <*> arbitrary
-          <*> pure Nothing
-          <*> (Just <$> arbitrary)
+          <*> (Left <$> arbitrary)
       ]
 
 instance Arbitrary LspIdRsp where


### PR DESCRIPTION
Close #191 

Todo:
- [x] add JSON roundtrip tests for `ResponseMessage` with valid values for `result` field (`string | number | boolean | object | null`);
- [x] check that invalid JSON (`result = null`(without `error` field) and both of them being absent) is handled properly;
- [x] remove `either` dependency (see https://github.com/alanz/haskell-lsp/pull/234#discussion_r395584136);
- [x] remove prefix in `ResponseMessage` fields (see https://github.com/alanz/haskell-lsp/pull/234#discussion_r395561185);  
