### PR TITLE
Split out the Hover request into its own file

### DIFF
--- a/haskell-lsp-types/haskell-lsp-types.cabal
+++ b/haskell-lsp-types/haskell-lsp-types.cabal
@@ -32,6 +32,7 @@ library
                      , Language.Haskell.LSP.Types.Diagnostic
                      , Language.Haskell.LSP.Types.DocumentFilter
                      , Language.Haskell.LSP.Types.FoldingRange
+                     , Language.Haskell.LSP.Types.Hover
                      , Language.Haskell.LSP.Types.List
                      , Language.Haskell.LSP.Types.Location
                      , Language.Haskell.LSP.Types.MarkupContent

--- a/haskell-lsp-types/src/Language/Haskell/LSP/Types.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/Types.hs
@@ -7,6 +7,7 @@ module Language.Haskell.LSP.Types
   , module Language.Haskell.LSP.Types.Diagnostic
   , module Language.Haskell.LSP.Types.DocumentFilter
   , module Language.Haskell.LSP.Types.FoldingRange
+  , module Language.Haskell.LSP.Types.Hover
   , module Language.Haskell.LSP.Types.List
   , module Language.Haskell.LSP.Types.Location
   , module Language.Haskell.LSP.Types.MarkupContent
@@ -29,6 +30,7 @@ import           Language.Haskell.LSP.Types.Completion
 import           Language.Haskell.LSP.Types.Diagnostic
 import           Language.Haskell.LSP.Types.DocumentFilter
 import           Language.Haskell.LSP.Types.FoldingRange
+import           Language.Haskell.LSP.Types.Hover
 import           Language.Haskell.LSP.Types.List
 import           Language.Haskell.LSP.Types.Location
 import           Language.Haskell.LSP.Types.MarkupContent

--- a/haskell-lsp-types/src/Language/Haskell/LSP/Types/DataTypesJSON.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/Types/DataTypesJSON.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE DeriveTraversable          #-}
 {-# LANGUAGE DuplicateRecordFields      #-}
@@ -28,7 +27,6 @@ import           Language.Haskell.LSP.Types.Diagnostic
 import           Language.Haskell.LSP.Types.DocumentFilter
 import           Language.Haskell.LSP.Types.List
 import           Language.Haskell.LSP.Types.Location
-import           Language.Haskell.LSP.Types.MarkupContent
 import           Language.Haskell.LSP.Types.Message
 import           Language.Haskell.LSP.Types.Progress
 import           Language.Haskell.LSP.Types.Symbol
@@ -1725,138 +1723,6 @@ deriveJSON lspOptions ''PublishDiagnosticsParams
 
 
 type PublishDiagnosticsNotification = NotificationMessage ServerMethod PublishDiagnosticsParams
-
--- ---------------------------------------------------------------------
-{-
-Hover Request
-
-The hover request is sent from the client to the server to request hover
-information at a given text document position.
-
-    Changed: In 2.0 the request uses TextDocumentPositionParams with a proper
-    textDocument and position property. In 1.0 the uri of the referenced text
-    document was inlined into the params object.
-
-Request
-
-    method: 'textDocument/hover'
-    params: TextDocumentPositionParams
-
-Response
-
-    result: Hover | null defined as follows:
-
-
-/**
- * The result of a hover request.
- */
-interface Hover {
-        /**
-         * The hover's content
-         */
-        contents: MarkedString | MarkedString[] | MarkupContent;
-
-        /**
-         * An optional range is a range inside a text document
-         * that is used to visualize a hover, e.g. by changing the background color.
-         */
-        range?: Range;
-}
-
-
-/**
- * MarkedString can be used to render human readable text. It is either a markdown string
- * or a code-block that provides a language and a code snippet. The language identifier
- * is semantically equal to the optional language identifier in fenced code blocks in GitHub
- * issues. See https://help.github.com/articles/creating-and-highlighting-code-blocks/#syntax-highlighting
- *
- * The pair of a language and a value is an equivalent to markdown:
- * ```${language}
- * ${value}
- * ```
- *
- * Note that markdown strings will be sanitized - that means html will be escaped.
-* @deprecated use MarkupContent instead.
-*/
-type MarkedString = string | { language: string; value: string };
-
-    error: code and message set in case an exception happens during the hover
-    request.
-
-Registration Options: TextDocumentRegistrationOptions
-
--}
-
-data LanguageString =
-  LanguageString
-    { _language :: Text
-    , _value    :: Text
-    } deriving (Read,Show,Eq)
-
-deriveJSON lspOptions ''LanguageString
-
-{-# DEPRECATED MarkedString, PlainString, CodeString "Use MarkupContent instead, since 3.3.0 (11/24/2017)" #-}
-data MarkedString =
-    PlainString T.Text
-  | CodeString LanguageString
-    deriving (Eq,Read,Show)
-
-instance ToJSON MarkedString where
-  toJSON (PlainString x) = toJSON x
-  toJSON (CodeString  x) = toJSON x
-instance FromJSON MarkedString where
-  parseJSON (A.String t) = pure $ PlainString t
-  parseJSON o            = CodeString <$> parseJSON o
-
--- -------------------------------------
-
-data HoverContents =
-    HoverContentsMS (List MarkedString)
-  | HoverContents   MarkupContent
-  deriving (Read,Show,Eq)
-
-instance ToJSON HoverContents where
-  toJSON (HoverContentsMS  x) = toJSON x
-  toJSON (HoverContents    x) = toJSON x
-instance FromJSON HoverContents where
-  parseJSON v@(A.String _) = HoverContentsMS <$> parseJSON v
-  parseJSON v@(A.Array _)  = HoverContentsMS <$> parseJSON v
-  parseJSON v@(A.Object _) = HoverContents   <$> parseJSON v
-                         <|> HoverContentsMS <$> parseJSON v
-  parseJSON _ = mempty
-
--- -------------------------------------
-
-#if __GLASGOW_HASKELL__ >= 804
-instance Semigroup HoverContents where
-  (<>) = mappend
-#endif
-
-instance Monoid HoverContents where
-  mempty = HoverContentsMS (List [])
-
-  HoverContents h1   `mappend` HoverContents         h2   = HoverContents (h1 `mappend` h2)
-  HoverContents h1   `mappend` HoverContentsMS (List h2s) = HoverContents (mconcat (h1: (map toMarkupContent h2s)))
-  HoverContentsMS (List h1s) `mappend` HoverContents         h2    = HoverContents (mconcat ((map toMarkupContent h1s) ++ [h2]))
-  HoverContentsMS (List h1s) `mappend` HoverContentsMS (List h2s) = HoverContentsMS (List (h1s `mappend` h2s))
-
-toMarkupContent :: MarkedString -> MarkupContent
-toMarkupContent (PlainString s) = unmarkedUpContent s
-toMarkupContent (CodeString (LanguageString lang s)) = markedUpContent lang s
-
--- -------------------------------------
-
-data Hover =
-  Hover
-    { _contents :: HoverContents
-    , _range    :: Maybe Range
-    } deriving (Read,Show,Eq)
-
-deriveJSON lspOptions ''Hover
-
-
-type HoverRequest = RequestMessage ClientMethod TextDocumentPositionParams (Maybe Hover)
-type HoverResponse = ResponseMessage (Maybe Hover)
 
 -- ---------------------------------------------------------------------
 {-

--- a/haskell-lsp-types/src/Language/Haskell/LSP/Types/Hover.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/Types/Hover.hs
@@ -1,0 +1,151 @@
+{-# LANGUAGE CPP              #-}
+{-# LANGUAGE TemplateHaskell  #-}
+{-# LANGUAGE DuplicateRecordFields      #-}
+module Language.Haskell.LSP.Types.Hover where
+
+import           Control.Applicative
+import           Data.Aeson
+import           Data.Aeson.TH
+import           Data.Text                      ( Text )
+import           Language.Haskell.LSP.Types.Constants
+import           Language.Haskell.LSP.Types.List
+import           Language.Haskell.LSP.Types.Location
+import           Language.Haskell.LSP.Types.MarkupContent
+import           Language.Haskell.LSP.Types.Message
+import           Language.Haskell.LSP.Types.TextDocument
+
+-- ---------------------------------------------------------------------
+
+{-
+/**
+ * MarkedString can be used to render human readable text. It is either a markdown string
+ * or a code-block that provides a language and a code snippet. The language identifier
+ * is semantically equal to the optional language identifier in fenced code blocks in GitHub
+ * issues. See https://help.github.com/articles/creating-and-highlighting-code-blocks/#syntax-highlighting
+ *
+ * The pair of a language and a value is an equivalent to markdown:
+ * ```${language}
+ * ${value}
+ * ```
+ *
+ * Note that markdown strings will be sanitized - that means html will be escaped.
+* @deprecated use MarkupContent instead.
+*/
+type MarkedString = string | { language: string; value: string };
+
+    error: code and message set in case an exception happens during the hover
+    request.
+
+Registration Options: TextDocumentRegistrationOptions
+
+-}
+
+data LanguageString =
+  LanguageString
+    { _language :: Text
+    , _value    :: Text
+    } deriving (Read,Show,Eq)
+
+deriveJSON lspOptions ''LanguageString
+
+{-# DEPRECATED MarkedString, PlainString, CodeString "Use MarkupContent instead, since 3.3.0 (11/24/2017)" #-}
+data MarkedString =
+    PlainString Text
+  | CodeString LanguageString
+    deriving (Eq,Read,Show)
+
+instance ToJSON MarkedString where
+  toJSON (PlainString x) = toJSON x
+  toJSON (CodeString  x) = toJSON x
+instance FromJSON MarkedString where
+  parseJSON (String t) = pure $ PlainString t
+  parseJSON o            = CodeString <$> parseJSON o
+
+-- ---------------------------------------------------------------------
+{-
+Hover Request
+
+The hover request is sent from the client to the server to request hover
+information at a given text document position.
+
+    Changed: In 2.0 the request uses TextDocumentPositionParams with a proper
+    textDocument and position property. In 1.0 the uri of the referenced text
+    document was inlined into the params object.
+
+Request
+
+    method: 'textDocument/hover'
+    params: TextDocumentPositionParams
+
+Response
+
+    result: Hover | null defined as follows:
+
+
+/**
+ * The result of a hover request.
+ */
+interface Hover {
+        /**
+         * The hover's content
+         */
+        contents: MarkedString | MarkedString[] | MarkupContent;
+
+        /**
+         * An optional range is a range inside a text document
+         * that is used to visualize a hover, e.g. by changing the background color.
+         */
+        range?: Range;
+}
+
+-}
+
+
+-- -------------------------------------
+
+data HoverContents =
+    HoverContentsMS (List MarkedString)
+  | HoverContents   MarkupContent
+  deriving (Read,Show,Eq)
+
+instance ToJSON HoverContents where
+  toJSON (HoverContentsMS  x) = toJSON x
+  toJSON (HoverContents    x) = toJSON x
+instance FromJSON HoverContents where
+  parseJSON v@(String _) = HoverContentsMS <$> parseJSON v
+  parseJSON v@(Array _)  = HoverContentsMS <$> parseJSON v
+  parseJSON v@(Object _) = HoverContents   <$> parseJSON v
+                         <|> HoverContentsMS <$> parseJSON v
+  parseJSON _ = mempty
+
+-- -------------------------------------
+
+#if __GLASGOW_HASKELL__ >= 804
+instance Semigroup HoverContents where
+  (<>) = mappend
+#endif
+
+instance Monoid HoverContents where
+  mempty = HoverContentsMS (List [])
+
+  HoverContents h1   `mappend` HoverContents         h2   = HoverContents (h1 `mappend` h2)
+  HoverContents h1   `mappend` HoverContentsMS (List h2s) = HoverContents (mconcat (h1: (map toMarkupContent h2s)))
+  HoverContentsMS (List h1s) `mappend` HoverContents         h2    = HoverContents (mconcat ((map toMarkupContent h1s) ++ [h2]))
+  HoverContentsMS (List h1s) `mappend` HoverContentsMS (List h2s) = HoverContentsMS (List (h1s `mappend` h2s))
+
+toMarkupContent :: MarkedString -> MarkupContent
+toMarkupContent (PlainString s) = unmarkedUpContent s
+toMarkupContent (CodeString (LanguageString lang s)) = markedUpContent lang s
+
+-- -------------------------------------
+
+data Hover =
+  Hover
+    { _contents :: HoverContents
+    , _range    :: Maybe Range
+    } deriving (Read,Show,Eq)
+
+deriveJSON lspOptions ''Hover
+
+type HoverRequest = RequestMessage ClientMethod TextDocumentPositionParams (Maybe Hover)
+type HoverResponse = ResponseMessage (Maybe Hover)

--- a/haskell-lsp-types/src/Language/Haskell/LSP/Types/Lens.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/Types/Lens.hs
@@ -14,6 +14,7 @@ import           Language.Haskell.LSP.Types.DataTypesJSON
 import           Language.Haskell.LSP.Types.Diagnostic
 import           Language.Haskell.LSP.Types.DocumentFilter
 import           Language.Haskell.LSP.Types.FoldingRange
+import           Language.Haskell.LSP.Types.Hover
 import           Language.Haskell.LSP.Types.Message
 import           Language.Haskell.LSP.Types.Location
 import           Language.Haskell.LSP.Types.Symbol

--- a/haskell-lsp-types/src/Language/Haskell/LSP/Types/MarkupContent.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/Types/MarkupContent.hs
@@ -156,3 +156,4 @@ instance Monoid MarkupContent where
   MarkupContent _           s1 `mappend` MarkupContent MkMarkdown  s2 = MarkupContent MkMarkdown  (s1 `mappend` s2)
 
 -- ---------------------------------------------------------------------
+


### PR DESCRIPTION
The real reason for this? To remove CPP from DataTypesJSON, and thus to remove a preprocessor error/warning caused by one of the TypeScript documentation comments containing a `/**`
