### PR TITLE
Rework capture logic

### DIFF
--- a/src/Language/Haskell/LSP/Capture.hs
+++ b/src/Language/Haskell/LSP/Capture.hs
@@ -1,30 +1,46 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE OverloadedStrings #-}
-module Language.Haskell.LSP.Capture where
+module Language.Haskell.LSP.Capture
+  ( Event(..)
+  , CaptureContext
+  , noCapture
+  , captureToFile
+  , captureFromClient
+  , captureFromServer
+  ) where
 
 import Data.Aeson
 import Data.ByteString.Lazy.Char8 as BSL
 import Data.Time.Clock
 import GHC.Generics
 import Language.Haskell.LSP.Messages
+import System.IO
 
 data Event = FromClient UTCTime FromClientMessage
            | FromServer UTCTime FromServerMessage
   deriving (Show, Eq, Generic, ToJSON, FromJSON)
 
-captureFromServer :: FromServerMessage -> Maybe FilePath -> IO ()
-captureFromServer _ Nothing = return ()
-captureFromServer msg (Just fp) = do
+data CaptureContext = NoCapture | CaptureToFile Handle
+
+noCapture :: CaptureContext
+noCapture = NoCapture
+
+captureToFile :: FilePath -> IO CaptureContext
+captureToFile fname = CaptureToFile <$> openFile fname WriteMode
+
+captureFromServer :: FromServerMessage -> CaptureContext -> IO ()
+captureFromServer _ NoCapture = return ()
+captureFromServer msg (CaptureToFile fp) = do
   time <- getCurrentTime
   let entry = FromServer time msg
 
-  BSL.appendFile fp $ BSL.append (encode entry) "\n"
+  BSL.hPutStrLn fp (encode entry)
 
-captureFromClient :: FromClientMessage -> Maybe FilePath -> IO ()
-captureFromClient _ Nothing = return ()
-captureFromClient msg (Just fp) = do
+captureFromClient :: FromClientMessage -> CaptureContext -> IO ()
+captureFromClient _ NoCapture = return ()
+captureFromClient msg (CaptureToFile fp) = do
   time <- getCurrentTime
   let entry = FromClient time msg
 
-  BSL.appendFile fp $ BSL.append (encode entry) "\n"
+  BSL.hPutStrLn fp $ BSL.append (encode entry) "\n"

--- a/src/Language/Haskell/LSP/Capture.hs
+++ b/src/Language/Haskell/LSP/Capture.hs
@@ -32,7 +32,7 @@ noCapture = NoCapture
 
 captureToFile :: FilePath -> IO CaptureContext
 captureToFile fname = do
-    logs $ "haskell-lsp:Logging to " <> fname
+    logs $ "haskell-lsp:Logging to " ++ fname
     chan <- newTChanIO
     _tid <- forkIO $ withFile fname WriteMode $ writeToHandle chan
     return $ Capture chan

--- a/src/Language/Haskell/LSP/Core.hs
+++ b/src/Language/Haskell/LSP/Core.hs
@@ -27,6 +27,7 @@ module Language.Haskell.LSP.Core (
   , sendErrorLogS
   , sendErrorShowS
   , reverseSortEdit
+  , Priority(..)
   ) where
 
 import           Control.Concurrent.Async

--- a/src/Language/Haskell/LSP/Core.hs
+++ b/src/Language/Haskell/LSP/Core.hs
@@ -86,7 +86,7 @@ data LanguageContextData config =
   , resConfig              :: !(Maybe config)
   , resLspId               :: !(TVar Int)
   , resLspFuncs            :: LspFuncs config -- NOTE: Cannot be strict, lazy initialization
-  , resCaptureFile         :: !(Maybe FilePath)
+  , resCaptureContext      :: !CaptureContext
   , resWorkspaceFolders    :: ![J.WorkspaceFolder]
   , resProgressData        :: !ProgressData
   }
@@ -348,7 +348,7 @@ handlerMap _ h J.Exit                            =
       ctx <- readTVarIO ctxVar
       -- Capture exit notification
       case J.fromJSON v :: J.Result J.ExitNotification of
-        J.Success n -> captureFromClient (NotExit n) (resCaptureFile ctx)
+        J.Success n -> captureFromClient (NotExit n) (resCaptureContext ctx)
         J.Error _ -> return ()
       logm $ B.pack "haskell-lsp:Got exit, exiting"
       exitSuccess
@@ -417,7 +417,7 @@ hh mVfs wrapper mh tvarDat json = do
 
           ctx <- readTVarIO tvarDat
           let req' = wrapper req
-          captureFromClient req' (resCaptureFile ctx)
+          captureFromClient req' (resCaptureContext ctx)
 
           case mh of
             Just h -> h req
@@ -484,7 +484,7 @@ handleMessageWithConfigChange notification parseConfig mh tvarDat json =
     J.Success req -> do
       ctx <- readTVarIO tvarDat
 
-      captureFromClient (notification req) (resCaptureFile ctx)
+      captureFromClient (notification req) (resCaptureContext ctx)
 
       case parseConfig req of
         Left err -> do
@@ -605,10 +605,10 @@ _ERR_MSG_URL = [ "`stack update` and install new haskell-lsp."
 -- |
 --
 --
-defaultLanguageContextData :: Handlers -> Options -> LspFuncs config -> TVar Int -> SendFunc -> Maybe FilePath -> VFS -> LanguageContextData config
-defaultLanguageContextData h o lf tv sf cf vfs =
+defaultLanguageContextData :: Handlers -> Options -> LspFuncs config -> TVar Int -> SendFunc -> CaptureContext -> VFS -> LanguageContextData config
+defaultLanguageContextData h o lf tv sf cc vfs =
   LanguageContextData _INITIAL_RESPONSE_SEQUENCE h o sf (VFSData vfs mempty) mempty
-                      Nothing tv lf cf mempty defaultProgressData
+                      Nothing tv lf cc mempty defaultProgressData
 
 defaultProgressData :: ProgressData
 defaultProgressData = ProgressData 0 Map.empty

--- a/test/InitialConfigurationSpec.hs
+++ b/test/InitialConfigurationSpec.hs
@@ -6,6 +6,7 @@ import           Control.Concurrent.MVar
 import           Control.Concurrent.STM
 import           Data.Aeson
 import           Data.Default
+import           Language.Haskell.LSP.Capture
 import           Language.Haskell.LSP.Core
 import           Language.Haskell.LSP.Types
 import           Language.Haskell.LSP.VFS
@@ -40,7 +41,7 @@ spec =
                                                         undefined
                                                         tvarLspId
                                                         (const $ return ())
-                                                        Nothing
+                                                        noCapture
                                                         vfs
 
     let putMsg msg =

--- a/test/WorkspaceFoldersSpec.hs
+++ b/test/WorkspaceFoldersSpec.hs
@@ -6,6 +6,7 @@ import Control.Concurrent.MVar
 import Control.Concurrent.STM
 import Data.Aeson
 import Data.Default
+import Language.Haskell.LSP.Capture
 import Language.Haskell.LSP.Core
 import Language.Haskell.LSP.Types
 import Language.Haskell.LSP.VFS
@@ -31,7 +32,7 @@ spec =
                                                         undefined
                                                         tvarLspId
                                                         (const $ return ())
-                                                        Nothing
+                                                        noCapture
                                                         vfs
 
     let putMsg msg =


### PR DESCRIPTION
The previous mechanism was racy as it opened the capture file
on every event. If two requests came in close succession then one thread
could attempt to open the capture file while it was already open in
another thread.