### PR TITLE
Add hashWithSalt instances for Hashable

### DIFF
--- a/haskell-lsp-types/src/Language/Haskell/LSP/Types/Uri.hs
+++ b/haskell-lsp-types/src/Language/Haskell/LSP/Types/Uri.hs
@@ -54,6 +54,7 @@ instance Ord NormalizedUri where
 
 instance Hashable NormalizedUri where
   hash (NormalizedUri h _) = h
+  hashWithSalt salt (NormalizedUri h _) = hashWithSalt salt h
 
 instance NFData NormalizedUri
 
@@ -174,6 +175,7 @@ instance Show NormalizedFilePath where
 
 instance Hashable NormalizedFilePath where
   hash (NormalizedFilePath uri _) = hash uri
+  hashWithSalt salt (NormalizedFilePath uri _) = hashWithSalt salt uri
 
 instance IsString NormalizedFilePath where
     fromString = toNormalizedFilePath


### PR DESCRIPTION
Having looked at ghcide, it always calls these methods via hashWithSalt. Having looked at hashable, it does appear that if you don't implement hashWithSalt then it's a generic method, which means in both cases it walks the FilePath, and avoids all your clever precomputing the Int trick. Much better to properly implement `hashWithSalt`, and it does seem to have some value of directly implementing `hash`.

I haven't profiled the code to confirm it is a speed up, but it seems highly likely!