### PR TITLE
Add signature help request to lsp-test

### DIFF
--- a/lsp-test/src/Language/LSP/Test.hs
+++ b/lsp-test/src/Language/LSP/Test.hs
@@ -110,6 +110,9 @@ module Language.LSP.Test (
   -- ** Hover
   getHover,
 
+  -- ** Signature Help
+  getSignatureHelp,
+
   -- ** Highlights
   getHighlights,
 
@@ -932,6 +935,12 @@ getHover :: TextDocumentIdentifier -> Position -> Session (Maybe Hover)
 getHover doc pos =
   let params = HoverParams doc pos Nothing
    in nullToMaybe . getResponseResult <$> request SMethod_TextDocumentHover params
+
+-- | Returns the signature help at the specified position.
+getSignatureHelp :: TextDocumentIdentifier -> Position -> Session (Maybe SignatureHelp)
+getSignatureHelp doc pos =
+  let params = SignatureHelpParams doc pos Nothing Nothing
+   in nullToMaybe . getResponseResult <$> request SMethod_TextDocumentSignatureHelp params
 
 -- | Returns the highlighted occurrences of the term at the specified position
 getHighlights :: TextDocumentIdentifier -> Position -> Session [DocumentHighlight]

--- a/lsp-test/test/DummyServer.hs
+++ b/lsp-test/test/DummyServer.hs
@@ -72,6 +72,12 @@ handlers =
             Right $
               InL $
                 Hover (InL (MarkupContent MarkupKind_PlainText "hello")) Nothing
+    , requestHandler SMethod_TextDocumentSignatureHelp $
+        \_req responder ->
+          responder $
+            Right $
+              InL $
+                SignatureHelp [] Nothing Nothing
     , requestHandler SMethod_TextDocumentDocumentSymbol $
         \_req responder ->
           responder $

--- a/lsp-test/test/Test.hs
+++ b/lsp-test/test/Test.hs
@@ -307,6 +307,12 @@ main = hspec $ around withDummyServer $ do
       hover <- getHover doc (Position 45 9)
       liftIO $ hover `shouldSatisfy` isJust
 
+  describe "getSignatureHelp" $
+    it "works" $ \(hin, hout) -> runSessionWithHandles hin hout def fullLatestClientCaps "." $ do
+      doc <- openDoc "test/data/renamePass/Desktop/simple.hs" "haskell"
+      signatureHelp <- getSignatureHelp doc (Position 22 32)
+      liftIO $ signatureHelp `shouldSatisfy` isJust
+
   -- describe "getHighlights" $
   --   it "works" $ \(hin, hout) -> runSessionWithHandles hin hout def fullLatestClientCaps "." $ do
   --     doc <- openDoc "test/data/renamePass/Desktop/simple.hs" "haskell"


### PR DESCRIPTION
While [implementing][1] signature help for HLS, I noticed this request doesn't have any lsp-test helpers yet.

[1]: https://github.com/haskell/haskell-language-server/pull/4626
