### PR TITLE
Add a context parameter for getSignatureHelp

### DIFF
--- a/lsp-test/src/Language/LSP/Test.hs
+++ b/lsp-test/src/Language/LSP/Test.hs
@@ -937,9 +937,9 @@ getHover doc pos =
    in nullToMaybe . getResponseResult <$> request SMethod_TextDocumentHover params
 
 -- | Returns the signature help at the specified position.
-getSignatureHelp :: TextDocumentIdentifier -> Position -> Session (Maybe SignatureHelp)
-getSignatureHelp doc pos =
-  let params = SignatureHelpParams doc pos Nothing Nothing
+getSignatureHelp :: TextDocumentIdentifier -> Position -> Maybe SignatureHelpContext -> Session (Maybe SignatureHelp)
+getSignatureHelp doc pos mCtx =
+  let params = SignatureHelpParams doc pos Nothing mCtx
    in nullToMaybe . getResponseResult <$> request SMethod_TextDocumentSignatureHelp params
 
 -- | Returns the highlighted occurrences of the term at the specified position

--- a/lsp-test/test/Test.hs
+++ b/lsp-test/test/Test.hs
@@ -310,7 +310,7 @@ main = hspec $ around withDummyServer $ do
   describe "getSignatureHelp" $
     it "works" $ \(hin, hout) -> runSessionWithHandles hin hout def fullLatestClientCaps "." $ do
       doc <- openDoc "test/data/renamePass/Desktop/simple.hs" "haskell"
-      signatureHelp <- getSignatureHelp doc (Position 22 32)
+      signatureHelp <- getSignatureHelp doc (Position 22 32) Nothing
       liftIO $ signatureHelp `shouldSatisfy` isJust
 
   -- describe "getHighlights" $


### PR DESCRIPTION
I find it is useful to pass the context when implementing the signature help feature for HLS.

A follow-up of #621.