### PR TITLE
Fix semantic tokens dynamic registration and CantRegister log

### DIFF
--- a/lsp-types/src/Language/LSP/Protocol/Capabilities.hs
+++ b/lsp-types/src/Language/LSP/Protocol/Capabilities.hs
@@ -298,9 +298,10 @@ dynamicRegistrationSupported m caps = fromMaybe False $ case m of
   SMethod_TextDocumentMoniker -> caps ^? dyn m
   SMethod_TextDocumentPrepareTypeHierarchy -> caps ^? dyn m
   SMethod_TextDocumentDiagnostic -> caps ^? dyn m
-  -- semantic tokens is messed up due to it having you register with an otherwise non-existent method
-  -- SMethod_TextDocumentSemanticTokens       -> capDyn $ clientCaps ^? L.textDocument . _Just . L.semanticTokens . _Just
-  -- Notebook document methods alway support dynamic registration, it seems?
+  SMethod_TextDocumentSemanticTokensFull -> caps ^? dyn m
+  SMethod_TextDocumentSemanticTokensFullDelta -> caps ^? dyn m
+  SMethod_TextDocumentSemanticTokensRange -> caps ^? dyn m
+  -- Notebook document methods always support dynamic registration, it seems?
   _ -> Just False
  where
   dyn :: L.HasDynamicRegistration (ClientCapability m) (Maybe Bool) => SMethod m -> Traversal' ClientCapabilities Bool

--- a/lsp/src/Language/LSP/Server/Core.hs
+++ b/lsp/src/Language/LSP/Server/Core.hs
@@ -620,7 +620,7 @@ trySendRegistration logger method regOpts = do
 
       pure (Just $ RegistrationToken method regId)
     else do
-      logger <& CantRegister SMethod_WorkspaceDidChangeConfiguration `WithSeverity` Warning
+      logger <& CantRegister method `WithSeverity` Warning
       pure Nothing
 
 {- | Sends a @client/unregisterCapability@ request and removes the handler


### PR DESCRIPTION
Fixes two small but blocking issues in the dynamic registration path.

**1. `Capabilities.hs` — semantic tokens cases were commented out**

The three semantic tokens methods fell through to `_ -> Just False` in `dynamicRegistrationSupported`, so `trySendRegistration` always returned `Nothing` for them and logged `CantRegister`. The comment said they were "messed up" due to registering with a non-existent method, but that only affects the pseudo method `textDocument/semanticTokens`. The three actual dispatch methods (`SemanticTokensFull`, `SemanticTokensFullDelta`, `SemanticTokensRange`) all map to `SemanticTokensClientCapabilities` which has `_dynamicRegistration`, so the existing `dyn m` helper works fine.

**2. `Core.hs` L623 — wrong method in CantRegister log**

`trySendRegistration` was logging `SMethod_WorkspaceDidChangeConfiguration` hardcoded instead of the actual `method` parameter. One-word fix.

These two together are the prerequisite for haskell/haskell-language-server#4084.
