### PR TITLE
Ignore `SessionException` during test cleanup from listener thread

### DIFF
--- a/lsp-test/src/Language/LSP/Test/Session.hs
+++ b/lsp-test/src/Language/LSP/Test/Session.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE ViewPatterns #-}
 
 module Language.LSP.Test.Session
   ( Session(..)
@@ -302,7 +303,7 @@ runSession' serverIn serverOut mServerProc serverHandler config caps rootDir exi
         (ignoreRegistrationRequests config)
       runSession' = runSessionMonad context initState
 
-      errorHandler = throwTo mainThreadId :: SessionException -> IO ()
+      errorHandler e = throwTo mainThreadId (SomeAsyncException (e :: SessionException))
       serverListenerLauncher =
         async $ catch (serverHandler serverOut context) errorHandler
       msgTimeoutMs = messageTimeout config * 10^6
@@ -316,10 +317,20 @@ runSession' serverIn serverOut mServerProc serverHandler config caps rootDir exi
 #endif
                   cleanupProcess (Just serverIn, Just serverOut, Nothing, sp)
               | otherwise = pure ()
-        finally (timeout msgTimeoutMs (runSession' exitServer))
-                -- Make sure to kill the listener first, before closing
-                -- handles etc via cleanupProcess
-                (cancel async >> cleanup)
+
+        finally
+          -- If we get interrupted by the listener thread, we may be waiting
+          -- for a message that won't come / reading from a handle that's been
+          -- closed.
+          --
+          -- Seeing as we're in the cleanup stage already, ignore that specific
+          -- class of errors.
+          (void (timeout msgTimeoutMs (runSession' exitServer)) `catch`
+            (\(asyncExceptionFromException -> Just (_ :: SessionException)) -> pure ()))
+
+          -- Make sure to kill the listener first, before closing
+          -- handles etc via cleanupProcess
+          (cancel async >> cleanup)
 
   (result, _) <- bracket serverListenerLauncher
                          serverAndListenerFinalizer


### PR DESCRIPTION
Follows https://github.com/haskell/haskell-language-server/issues/4884#issuecomment-4189114049.

I get quite a few flaky errors when running HLS's `ghcide-tests` testsuite. 

The following is a small investigation into why. [This piece of code](https://github.com/haskell/haskell-language-server/blob/master/hls-test-utils/src/Test/Hls.hs?plain=1#L853-L856) is the failing bit. We create pipes and pass these to both `ghcide` and `lsp-test` for communication. Tests then intermittently fail with the following error:

<details><summary>Test Failure</summary>

```
ghcide
  constructor hover (#2904)
    ...
    ConstructorsLinear.hs
      ...
      C: FAIL
        Exception: Language server unexpectedly terminated
        HasCallStack backtrace:
          collectBacktraces, called at libraries/ghc-internal/src/GHC/Internal/Exception.hs:169:13 in ghc-internal:GHC.Internal.Exception
          toExceptionWithBacktrace, called at libraries/ghc-internal/src/GHC/Internal/IO.hs:260:11 in ghc-internal:GHC.Internal.IO
          throwIO, called at ./Control/Concurrent/Async.hs:110:7 in tasty-1.5.3-5b82fefc56677f15fc945a95865c9329582aa96d81dddfd360d944f99f7a8e90:Control.Concurrent.Async


        Use -p '/constructor hover (#2904)/&&/ConstructorsLinear.hs.C/' to rerun this test only.
```
</details>

Leading me to `lsp-test`'s [`getHeaders`](https://github.com/haskell/lsp/blob/be5a5ffcfa6c59469318a28c7bd4181000f6011e/lsp-test/src/Language/LSP/Test/Decoding.hs?plain=1#L45-L53), called when it tries to read from the pipe. Now, I spent quite a bit trying to track down why the handle was closed, but couldn't find anything definitive. The only `hClose` in this codepath is [this one](https://github.com/haskell/haskell-language-server/blob/177ca8e4e5a73d7d36cd8bd8e9c5bcd2f3cc6d61/hls-test-utils/src/Test/Hls.hs?plain=1#L857) that occurs _after_ the test is done.

Taking a defensive view and accepting that the pipe can be broken, leads to the question when it is acceptable that the pipe can be broken. I think that bit is here.

https://github.com/haskell/lsp/blob/2d2c468507cb8a01a99d0310f99707833989842d/lsp-test/src/Language/LSP/Test/Session.hs?plain=1#L319-L322 

When the server test session is done, and we're cleaning up the communication threads. The [error handler](https://github.com/haskell/lsp/blob/85af0bc51b1aa686a952665e8e0d3cf7b2d1d727/lsp-test/src/Language/Haskell/LSP/Test/Session.hs?plain=1#L259) in the listener thread can still throw the EOF error to the main thread though, interrupting the main thread that's doing the gentle shutdown of the language server.

<details><summary>Short aside on the cleanup</summary>

I was severely confused why that `finally` was there in the shutdown code. After all, it's in the `after` block of a `bracket`. It should always be ran already as `mask` is on. Even better, [this](https://hackage-content.haskell.org/package/base-4.22.0.0/docs/src/System.Timeout.html#timeout) huge comment on `timeout`, gives that timeout uses async exceptions to do it's thing, which in a masked setting means that the timeout is deferred until the masking state is dropped.

What I missed is (as always) interruptibility. During interruptible functions, i.e. blocking functions on `MVar`, async exceptions can occur so the `finally` is still relevant. 

</details>

The change in this PR stops the tests from being flaky (I can run the suite 100x without failures, which would have otherwise occurred within 1-5 runs).