### PR TITLE
feat: add getDocumentLinks for lsp-test

### DIFF
--- a/lsp-test/src/Language/LSP/Test.hs
+++ b/lsp-test/src/Language/LSP/Test.hs
@@ -145,6 +145,9 @@ module Language.LSP.Test (
   getWorkspaceSymbols,
   resolveWorkspaceSymbols,
 
+  -- ** Document Links
+  getDocumentLinks,
+
   -- ** Capabilities
   getRegisteredCapabilities,
 ) where
@@ -1062,6 +1065,11 @@ resolveWorkspaceSymbols :: WorkspaceSymbol -> Session WorkspaceSymbol
 resolveWorkspaceSymbols item = do
   rsp <- request SMethod_WorkspaceSymbolResolve item
   pure $ getResponseResult rsp
+
+getDocumentLinks :: TextDocumentIdentifier -> Session (Maybe [DocumentLink])
+getDocumentLinks doc =
+  let params = DocumentLinkParams Nothing Nothing doc
+   in nullToMaybe . getResponseResult <$> request SMethod_TextDocumentDocumentLink params
 
 {- | Returns a list of capabilities that the server has requested to /dynamically/
  register during the 'Session'.

--- a/lsp-test/test/DummyServer.hs
+++ b/lsp-test/test/DummyServer.hs
@@ -284,4 +284,14 @@ handlers =
             Success start = fromJSON data_
             ih = InlayHint{_data_ = Nothing, _tooltip = Just $ InL $ "start at " <> T.pack (show start), ..}
         resp $ Right ih
+    , requestHandler SMethod_TextDocumentDocumentLink $ \_req resp -> do
+        resp $
+          Right $
+            InL
+              [ DocumentLink
+                  (mkRange 0 0 0 5)
+                  (Just (Uri "file://..."))
+                  Nothing
+                  Nothing
+              ]
     ]

--- a/lsp-test/test/Test.hs
+++ b/lsp-test/test/Test.hs
@@ -470,3 +470,9 @@ main = hspec $ around withDummyServer $ do
       doc <- openDoc "test/data/renamePass/Desktop/simple.hs" "haskell"
       inlayHints <- getAndResolveInlayHints doc (Range (Position 1 2) (Position 3 4))
       liftIO $ head inlayHints ^. L.tooltip `shouldBe` Just (InL $ "start at " <> T.pack (show (Position 1 2)))
+
+  describe "getDocumentLinks" $
+    it "works" $ \(hin, hout) -> runSessionWithHandles hin hout def fullLatestClientCaps "." $ do
+      let doc = TextDocumentIdentifier (Uri "")
+      documentLinks <- getDocumentLinks doc
+      liftIO $ documentLinks `shouldSatisfy` isJust


### PR DESCRIPTION
Helper for `DocumentLinks` related tests